### PR TITLE
Implement F10 management API

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/i-got-this-faa/fbs/internal/auth"
 	"github.com/i-got-this-faa/fbs/internal/config"
 	httpapi "github.com/i-got-this-faa/fbs/internal/http"
+	"github.com/i-got-this-faa/fbs/internal/management"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 	"github.com/i-got-this-faa/fbs/internal/s3"
 	"github.com/i-got-this-faa/fbs/internal/server"
@@ -66,7 +67,20 @@ func main() {
 	authenticators = append(authenticators, &auth.SigV4Authenticator{Repo: sigv4Repo})
 	authChain := &auth.ChainAuthenticator{Authenticators: authenticators}
 
+	var managementAuthenticators []auth.Authenticator
+	if cfg.DevMode {
+		managementAuthenticators = append(managementAuthenticators, &auth.DevAuthenticator{})
+	}
+	managementAuthenticators = append(managementAuthenticators, &auth.BearerAuthenticator{Repo: userRepo})
+	managementAuthChain := &auth.ChainAuthenticator{Authenticators: managementAuthenticators}
+
 	bucketRepo := metadata.NewBucketRepository(db)
+	managementHandlers := &management.Handlers{
+		Management: metadata.NewManagementRepository(db),
+		Buckets:    bucketRepo,
+		Objects:    objectRepo,
+		Users:      userRepo,
+	}
 	objectHandlers := &s3.ObjectHandlers{
 		Users:   userRepo,
 		Buckets: bucketRepo,
@@ -76,6 +90,11 @@ func main() {
 	}
 
 	router := httpapi.NewRouter(cfg, logger, func(r chi.Router) {
+		r.Route("/api/management", func(managementRoutes chi.Router) {
+			managementRoutes.Use(auth.RequireAuthentication(managementAuthChain, management.WriteAuthError))
+			managementRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
+			management.RegisterRoutes(managementRoutes, managementHandlers)
+		})
 		r.Group(func(s3Routes chi.Router) {
 			s3Routes.Use(auth.RequireAuthentication(authChain, writeS3AuthError))
 			s3.RegisterBucketRoutes(s3Routes, objectHandlers)

--- a/internal/management/dto.go
+++ b/internal/management/dto.go
@@ -1,0 +1,129 @@
+package management
+
+import "github.com/i-got-this-faa/fbs/internal/metadata"
+
+type metricsResponse struct {
+	BucketCount      int64 `json:"bucket_count"`
+	ObjectCount      int64 `json:"object_count"`
+	TotalObjectBytes int64 `json:"total_object_bytes"`
+	UserCount        int64 `json:"user_count"`
+	ActiveUserCount  int64 `json:"active_user_count"`
+}
+
+type bucketsResponse struct {
+	Buckets []bucketSummaryResponse `json:"buckets"`
+}
+
+type bucketSummaryResponse struct {
+	Name             string `json:"name"`
+	OwnerID          string `json:"owner_id"`
+	CreatedAt        string `json:"created_at"`
+	ObjectCount      int64  `json:"object_count"`
+	TotalObjectBytes int64  `json:"total_object_bytes"`
+}
+
+type listObjectsResponse struct {
+	Bucket         string                  `json:"bucket"`
+	Prefix         string                  `json:"prefix"`
+	Delimiter      string                  `json:"delimiter"`
+	Limit          int                     `json:"limit"`
+	IsTruncated    bool                    `json:"is_truncated"`
+	NextCursor     string                  `json:"next_cursor"`
+	Objects        []objectSummaryResponse `json:"objects"`
+	CommonPrefixes []string                `json:"common_prefixes"`
+}
+
+type objectSummaryResponse struct {
+	Key         string `json:"key"`
+	Size        int64  `json:"size"`
+	ETag        string `json:"etag"`
+	ContentType string `json:"content_type"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type objectDetailResponse struct {
+	Object objectDetail `json:"object"`
+}
+
+type objectDetail struct {
+	Key         string `json:"key"`
+	Bucket      string `json:"bucket"`
+	Size        int64  `json:"size"`
+	ETag        string `json:"etag"`
+	ContentType string `json:"content_type"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+type keysResponse struct {
+	Keys []keyResponse `json:"keys"`
+}
+
+type keyResponse struct {
+	ID               string `json:"id"`
+	DisplayName      string `json:"display_name"`
+	AccessKeyID      string `json:"access_key_id"`
+	SigV4AccessKeyID string `json:"sigv4_access_key_id"`
+	Role             string `json:"role"`
+	IsActive         bool   `json:"is_active"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
+}
+
+type createKeyResponse struct {
+	Key         keyResponse   `json:"key"`
+	BearerToken string        `json:"bearer_token"`
+	SigV4       sigv4Response `json:"sigv4"`
+}
+
+type sigv4Response struct {
+	AccessKeyID string `json:"access_key_id"`
+	SecretKey   string `json:"secret_key"`
+}
+
+func bucketSummaryDTO(summary metadata.BucketSummary) bucketSummaryResponse {
+	return bucketSummaryResponse{
+		Name:             summary.Name,
+		OwnerID:          summary.OwnerID,
+		CreatedAt:        formatTime(summary.CreatedAt),
+		ObjectCount:      summary.ObjectCount,
+		TotalObjectBytes: summary.TotalObjectBytes,
+	}
+}
+
+func objectSummaryDTO(obj metadata.Object) objectSummaryResponse {
+	return objectSummaryResponse{
+		Key:         obj.Key,
+		Size:        obj.Size,
+		ETag:        obj.ETag,
+		ContentType: obj.ContentType,
+		CreatedAt:   formatTime(obj.CreatedAt),
+		UpdatedAt:   formatTime(obj.UpdatedAt),
+	}
+}
+
+func objectDetailDTO(obj metadata.Object) objectDetail {
+	return objectDetail{
+		Key:         obj.Key,
+		Bucket:      obj.BucketName,
+		Size:        obj.Size,
+		ETag:        obj.ETag,
+		ContentType: obj.ContentType,
+		CreatedAt:   formatTime(obj.CreatedAt),
+		UpdatedAt:   formatTime(obj.UpdatedAt),
+	}
+}
+
+func keyDTO(user metadata.User) keyResponse {
+	return keyResponse{
+		ID:               user.ID,
+		DisplayName:      user.DisplayName,
+		AccessKeyID:      user.AccessKeyID,
+		SigV4AccessKeyID: user.SigV4AccessKeyID,
+		Role:             user.Role,
+		IsActive:         user.IsActive,
+		CreatedAt:        formatTime(user.CreatedAt),
+		UpdatedAt:        formatTime(user.UpdatedAt),
+	}
+}

--- a/internal/management/handlers.go
+++ b/internal/management/handlers.go
@@ -1,0 +1,326 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+const (
+	defaultObjectListLimit = 100
+	maxObjectListLimit     = 1000
+)
+
+type Handlers struct {
+	Management metadata.ManagementRepository
+	Buckets    metadata.BucketRepository
+	Objects    metadata.ObjectRepository
+	Users      metadata.UserRepository
+}
+
+func (h *Handlers) Metrics(w http.ResponseWriter, r *http.Request) {
+	metrics, err := h.Management.Metrics(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load metrics")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, metricsResponse{
+		BucketCount:      metrics.BucketCount,
+		ObjectCount:      metrics.ObjectCount,
+		TotalObjectBytes: metrics.TotalObjectBytes,
+		UserCount:        metrics.UserCount,
+		ActiveUserCount:  metrics.ActiveUserCount,
+	})
+}
+
+func (h *Handlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
+	summaries, err := h.Management.ListBucketSummaries(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list buckets")
+		return
+	}
+
+	buckets := make([]bucketSummaryResponse, 0, len(summaries))
+	for _, summary := range summaries {
+		buckets = append(buckets, bucketSummaryDTO(summary))
+	}
+
+	writeJSON(w, http.StatusOK, bucketsResponse{Buckets: buckets})
+}
+
+func (h *Handlers) ListObjects(w http.ResponseWriter, r *http.Request) {
+	bucketName := strings.TrimSpace(chi.URLParam(r, "bucket"))
+	if !h.ensureBucket(w, r, bucketName) {
+		return
+	}
+
+	params, err := parseObjectListParams(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, err.Error())
+		return
+	}
+
+	objects, commonPrefixes, isTruncated, nextCursor, err := h.listObjects(r, bucketName, params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list objects")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listObjectsResponse{
+		Bucket:         bucketName,
+		Prefix:         params.prefix,
+		Delimiter:      params.delimiter,
+		Limit:          params.limit,
+		IsTruncated:    isTruncated,
+		NextCursor:     nextCursor,
+		Objects:        objects,
+		CommonPrefixes: commonPrefixes,
+	})
+}
+
+func (h *Handlers) GetObject(w http.ResponseWriter, r *http.Request) {
+	bucketName := strings.TrimSpace(chi.URLParam(r, "bucket"))
+	if !h.ensureBucket(w, r, bucketName) {
+		return
+	}
+
+	key := strings.TrimPrefix(chi.URLParam(r, "*"), "/")
+	if key == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "object not found")
+		return
+	}
+
+	obj, err := h.Objects.GetByKey(r.Context(), bucketName, key)
+	if errors.Is(err, metadata.ErrObjectNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "object not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load object")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, objectDetailResponse{Object: objectDetailDTO(*obj)})
+}
+
+func (h *Handlers) ListKeys(w http.ResponseWriter, r *http.Request) {
+	users, err := h.Users.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list keys")
+		return
+	}
+
+	keys := make([]keyResponse, 0, len(users))
+	for _, user := range users {
+		keys = append(keys, keyDTO(user))
+	}
+
+	writeJSON(w, http.StatusOK, keysResponse{Keys: keys})
+}
+
+func (h *Handlers) CreateKey(w http.ResponseWriter, r *http.Request) {
+	req, ok := decodeCreateKeyRequest(w, r)
+	if !ok {
+		return
+	}
+
+	issued, sigv4Creds, user, err := auth.CreateBearerToken(r.Context(), h.Users, req.displayName, req.role)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to create key")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, createKeyResponse{
+		Key:         keyDTO(*user),
+		BearerToken: issued.RawToken,
+		SigV4: sigv4Response{
+			AccessKeyID: sigv4Creds.AccessKeyID,
+			SecretKey:   sigv4Creds.SecretKey,
+		},
+	})
+}
+
+func (h *Handlers) DeleteKey(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "key not found")
+		return
+	}
+
+	err := h.Users.Delete(r.Context(), id)
+	if errors.Is(err, metadata.ErrUserNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "key not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to delete key")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handlers) ensureBucket(w http.ResponseWriter, r *http.Request, bucketName string) bool {
+	if bucketName == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "bucket not found")
+		return false
+	}
+
+	_, err := h.Buckets.GetByName(r.Context(), bucketName)
+	if errors.Is(err, metadata.ErrBucketNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "bucket not found")
+		return false
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load bucket")
+		return false
+	}
+
+	return true
+}
+
+type objectListParams struct {
+	prefix    string
+	delimiter string
+	cursor    string
+	limit     int
+}
+
+func parseObjectListParams(r *http.Request) (objectListParams, error) {
+	query := r.URL.Query()
+	limit := defaultObjectListLimit
+	if rawLimit := strings.TrimSpace(query.Get("limit")); rawLimit != "" {
+		parsedLimit, err := strconv.Atoi(rawLimit)
+		if err != nil || parsedLimit <= 0 {
+			return objectListParams{}, errors.New("limit must be a positive integer")
+		}
+		limit = parsedLimit
+	}
+	if limit > maxObjectListLimit {
+		limit = maxObjectListLimit
+	}
+
+	return objectListParams{
+		prefix:    query.Get("prefix"),
+		delimiter: query.Get("delimiter"),
+		cursor:    query.Get("cursor"),
+		limit:     limit,
+	}, nil
+}
+
+func (h *Handlers) listObjects(r *http.Request, bucketName string, params objectListParams) ([]objectSummaryResponse, []string, bool, string, error) {
+	if params.delimiter == "" {
+		objects, isTruncated, err := h.Objects.List(r.Context(), bucketName, params.prefix, params.cursor, params.limit)
+		if err != nil {
+			return nil, nil, false, "", err
+		}
+
+		responseObjects := make([]objectSummaryResponse, 0, len(objects))
+		for _, obj := range objects {
+			responseObjects = append(responseObjects, objectSummaryDTO(obj))
+		}
+
+		nextCursor := ""
+		if isTruncated && len(objects) > 0 {
+			nextCursor = objects[len(objects)-1].Key
+		}
+		return responseObjects, []string{}, isTruncated, nextCursor, nil
+	}
+
+	entries, err := h.Objects.ListDelimited(r.Context(), bucketName, params.prefix, params.cursor, params.delimiter, params.limit)
+	if err != nil {
+		return nil, nil, false, "", err
+	}
+
+	isTruncated := len(entries) > params.limit
+	if isTruncated {
+		entries = entries[:params.limit]
+	}
+
+	objects := make([]objectSummaryResponse, 0, len(entries))
+	commonPrefixes := make([]string, 0, len(entries))
+	nextCursor := ""
+	for _, entry := range entries {
+		nextCursor = entry.CursorKey
+		if entry.IsPrefix {
+			commonPrefixes = append(commonPrefixes, entry.VirtualKey)
+			continue
+		}
+		if entry.Object != nil {
+			objects = append(objects, objectSummaryDTO(*entry.Object))
+		}
+	}
+	if !isTruncated {
+		nextCursor = ""
+	}
+
+	return objects, commonPrefixes, isTruncated, nextCursor, nil
+}
+
+type createKeyInput struct {
+	displayName string
+	role        string
+}
+
+func decodeCreateKeyRequest(w http.ResponseWriter, r *http.Request) (createKeyInput, bool) {
+	var rawFields map[string]json.RawMessage
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&rawFields); err != nil {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+		return createKeyInput{}, false
+	}
+
+	for field := range rawFields {
+		if field != "display_name" && field != "role" {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+			return createKeyInput{}, false
+		}
+	}
+
+	displayName, ok := decodeStringField(w, rawFields, "display_name")
+	if !ok {
+		return createKeyInput{}, false
+	}
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "display_name is required")
+		return createKeyInput{}, false
+	}
+
+	role := "member"
+	if _, exists := rawFields["role"]; exists {
+		decodedRole, ok := decodeStringField(w, rawFields, "role")
+		if !ok {
+			return createKeyInput{}, false
+		}
+		role = strings.TrimSpace(decodedRole)
+	}
+	if role != "admin" && role != "member" {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "role must be admin or member")
+		return createKeyInput{}, false
+	}
+
+	return createKeyInput{displayName: displayName, role: role}, true
+}
+
+func decodeStringField(w http.ResponseWriter, rawFields map[string]json.RawMessage, field string) (string, bool) {
+	rawValue, exists := rawFields[field]
+	if !exists {
+		return "", true
+	}
+
+	var value string
+	if err := json.Unmarshal(rawValue, &value); err != nil || string(rawValue) == "null" {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, field+" must be a string")
+		return "", false
+	}
+
+	return value, true
+}

--- a/internal/management/handlers.go
+++ b/internal/management/handlers.go
@@ -164,6 +164,7 @@ func (h *Handlers) DeleteKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	setNoStoreHeaders(w)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/management/handlers_test.go
+++ b/internal/management/handlers_test.go
@@ -261,6 +261,12 @@ func TestManagementCreateKeyReturnsGeneratedSecretsOnce(t *testing.T) {
 	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if got := resp.Header.Get("Pragma"); got != "no-cache" {
+		t.Fatalf("Pragma = %q, want no-cache", got)
+	}
 
 	var body struct {
 		Key struct {
@@ -305,10 +311,11 @@ func TestManagementInvalidCreateKeyPayloadReturnsBadRequest(t *testing.T) {
 	}
 	for _, payload := range cases {
 		resp := env.do(t, http.MethodPost, "/api/management/keys", env.adminToken, strings.NewReader(payload))
-		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusBadRequest {
+			resp.Body.Close()
 			t.Fatalf("payload %s status = %d, want %d", payload, resp.StatusCode, http.StatusBadRequest)
 		}
+		resp.Body.Close()
 	}
 }
 

--- a/internal/management/handlers_test.go
+++ b/internal/management/handlers_test.go
@@ -1,0 +1,516 @@
+package management_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/config"
+	httpapi "github.com/i-got-this-faa/fbs/internal/http"
+	"github.com/i-got-this-faa/fbs/internal/management"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+type managementTestEnv struct {
+	router       http.Handler
+	db           *sql.DB
+	adminToken   string
+	adminUserID  string
+	memberToken  string
+	memberUserID string
+	memberSigV4  auth.SigV4Credentials
+}
+
+func TestManagementMetrics(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	resp := env.do(t, http.MethodGet, "/api/management/metrics", env.adminToken, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		BucketCount      int64 `json:"bucket_count"`
+		ObjectCount      int64 `json:"object_count"`
+		TotalObjectBytes int64 `json:"total_object_bytes"`
+		UserCount        int64 `json:"user_count"`
+		ActiveUserCount  int64 `json:"active_user_count"`
+	}
+	decodeResponse(t, resp, &body)
+
+	if body.BucketCount != 2 || body.ObjectCount != 4 || body.TotalObjectBytes != 100 || body.UserCount != 2 || body.ActiveUserCount != 2 {
+		t.Fatalf("metrics = %+v, want bucket=2 object=4 bytes=100 users=2 active=2", body)
+	}
+}
+
+func TestManagementListBuckets(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	resp := env.do(t, http.MethodGet, "/api/management/buckets", env.adminToken, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Buckets []struct {
+			Name             string `json:"name"`
+			OwnerID          string `json:"owner_id"`
+			CreatedAt        string `json:"created_at"`
+			ObjectCount      int64  `json:"object_count"`
+			TotalObjectBytes int64  `json:"total_object_bytes"`
+		} `json:"buckets"`
+	}
+	decodeResponse(t, resp, &body)
+
+	if len(body.Buckets) != 2 {
+		t.Fatalf("len(buckets) = %d, want 2", len(body.Buckets))
+	}
+	photos := body.Buckets[0]
+	if photos.Name != "photos" || photos.ObjectCount != 3 || photos.TotalObjectBytes != 60 {
+		t.Fatalf("photos summary = %+v, want name=photos count=3 bytes=60", photos)
+	}
+	if photos.OwnerID == "" || photos.CreatedAt == "" {
+		t.Fatalf("photos summary missing owner/created_at: %+v", photos)
+	}
+}
+
+func TestManagementListObjectsSupportsPrefixDelimiterCursorAndLimit(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	delimited := env.do(t, http.MethodGet, "/api/management/buckets/photos/objects?prefix=2026/&delimiter=/&limit=100", env.adminToken, nil)
+	defer delimited.Body.Close()
+
+	if delimited.StatusCode != http.StatusOK {
+		t.Fatalf("delimited status = %d, want %d", delimited.StatusCode, http.StatusOK)
+	}
+
+	var delimitedBody struct {
+		Bucket      string `json:"bucket"`
+		Prefix      string `json:"prefix"`
+		Delimiter   string `json:"delimiter"`
+		Limit       int    `json:"limit"`
+		IsTruncated bool   `json:"is_truncated"`
+		NextCursor  string `json:"next_cursor"`
+		Objects     []struct {
+			Key         string `json:"key"`
+			Size        int64  `json:"size"`
+			ETag        string `json:"etag"`
+			ContentType string `json:"content_type"`
+			CreatedAt   string `json:"created_at"`
+			UpdatedAt   string `json:"updated_at"`
+		} `json:"objects"`
+		CommonPrefixes []string `json:"common_prefixes"`
+	}
+	decodeResponse(t, delimited, &delimitedBody)
+
+	if delimitedBody.Bucket != "photos" || delimitedBody.Prefix != "2026/" || delimitedBody.Delimiter != "/" || delimitedBody.Limit != 100 {
+		t.Fatalf("list metadata = %+v", delimitedBody)
+	}
+	if len(delimitedBody.Objects) != 1 || delimitedBody.Objects[0].Key != "2026/image.jpg" {
+		t.Fatalf("objects = %+v, want 2026/image.jpg only", delimitedBody.Objects)
+	}
+	if len(delimitedBody.CommonPrefixes) != 1 || delimitedBody.CommonPrefixes[0] != "2026/raw/" {
+		t.Fatalf("common_prefixes = %+v, want 2026/raw/", delimitedBody.CommonPrefixes)
+	}
+
+	firstPage := env.do(t, http.MethodGet, "/api/management/buckets/photos/objects?limit=1", env.adminToken, nil)
+	defer firstPage.Body.Close()
+
+	var firstPageBody struct {
+		IsTruncated bool   `json:"is_truncated"`
+		NextCursor  string `json:"next_cursor"`
+		Objects     []struct {
+			Key string `json:"key"`
+		} `json:"objects"`
+	}
+	decodeResponse(t, firstPage, &firstPageBody)
+	if !firstPageBody.IsTruncated || firstPageBody.NextCursor == "" || len(firstPageBody.Objects) != 1 {
+		t.Fatalf("first page = %+v, want truncated single object with cursor", firstPageBody)
+	}
+
+	secondPage := env.do(t, http.MethodGet, "/api/management/buckets/photos/objects?limit=1&cursor="+firstPageBody.NextCursor, env.adminToken, nil)
+	defer secondPage.Body.Close()
+
+	var secondPageBody struct {
+		Objects []struct {
+			Key string `json:"key"`
+		} `json:"objects"`
+	}
+	decodeResponse(t, secondPage, &secondPageBody)
+	if len(secondPageBody.Objects) != 1 || secondPageBody.Objects[0].Key <= firstPageBody.Objects[0].Key {
+		t.Fatalf("second page = %+v, want key after %q", secondPageBody, firstPageBody.Objects[0].Key)
+	}
+}
+
+func TestManagementObjectDetailSupportsSlashKeys(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	resp := env.do(t, http.MethodGet, "/api/management/buckets/photos/objects/2026/image.jpg", env.adminToken, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var body struct {
+		Object struct {
+			Key         string `json:"key"`
+			Bucket      string `json:"bucket"`
+			Size        int64  `json:"size"`
+			ETag        string `json:"etag"`
+			ContentType string `json:"content_type"`
+			CreatedAt   string `json:"created_at"`
+			UpdatedAt   string `json:"updated_at"`
+			StoragePath string `json:"storage_path"`
+		} `json:"object"`
+	}
+	decodeResponse(t, resp, &body)
+
+	if body.Object.Key != "2026/image.jpg" || body.Object.Bucket != "photos" || body.Object.StoragePath != "" {
+		t.Fatalf("object detail = %+v", body.Object)
+	}
+}
+
+func TestManagementMissingBucketAndObjectReturnNotFound(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	missingBucket := env.do(t, http.MethodGet, "/api/management/buckets/missing/objects", env.adminToken, nil)
+	defer missingBucket.Body.Close()
+	if missingBucket.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing bucket status = %d, want %d", missingBucket.StatusCode, http.StatusNotFound)
+	}
+
+	missingObject := env.do(t, http.MethodGet, "/api/management/buckets/photos/objects/missing.jpg", env.adminToken, nil)
+	defer missingObject.Body.Close()
+	if missingObject.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing object status = %d, want %d", missingObject.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestManagementListKeysExcludesSecrets(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	resp := env.do(t, http.MethodGet, "/api/management/keys", env.adminToken, nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	bodyBytes := readBody(t, resp)
+	bodyText := string(bodyBytes)
+	if strings.Contains(bodyText, "secret_hash") || strings.Contains(bodyText, env.memberToken) || strings.Contains(bodyText, env.memberSigV4.SecretKey) {
+		t.Fatalf("keys response exposed a secret: %s", bodyText)
+	}
+
+	var body struct {
+		Keys []struct {
+			ID               string `json:"id"`
+			DisplayName      string `json:"display_name"`
+			AccessKeyID      string `json:"access_key_id"`
+			SigV4AccessKeyID string `json:"sigv4_access_key_id"`
+			Role             string `json:"role"`
+			IsActive         bool   `json:"is_active"`
+			CreatedAt        string `json:"created_at"`
+			UpdatedAt        string `json:"updated_at"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Keys) != 2 {
+		t.Fatalf("len(keys) = %d, want 2", len(body.Keys))
+	}
+}
+
+func TestManagementCreateKeyReturnsGeneratedSecretsOnce(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	payload := strings.NewReader(`{"display_name":" Dashboard Admin ","role":"admin"}`)
+
+	resp := env.do(t, http.MethodPost, "/api/management/keys", env.adminToken, payload)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+
+	var body struct {
+		Key struct {
+			ID               string `json:"id"`
+			DisplayName      string `json:"display_name"`
+			AccessKeyID      string `json:"access_key_id"`
+			SigV4AccessKeyID string `json:"sigv4_access_key_id"`
+			Role             string `json:"role"`
+			IsActive         bool   `json:"is_active"`
+		} `json:"key"`
+		BearerToken string `json:"bearer_token"`
+		SigV4       struct {
+			AccessKeyID string `json:"access_key_id"`
+			SecretKey   string `json:"secret_key"`
+		} `json:"sigv4"`
+	}
+	decodeResponse(t, resp, &body)
+
+	if body.Key.DisplayName != "Dashboard Admin" || body.Key.Role != "admin" || !body.Key.IsActive {
+		t.Fatalf("created key = %+v", body.Key)
+	}
+	if body.BearerToken == "" || body.SigV4.AccessKeyID == "" || body.SigV4.SecretKey == "" {
+		t.Fatalf("create key did not return generated credentials: %+v", body)
+	}
+
+	listResp := env.do(t, http.MethodGet, "/api/management/keys", env.adminToken, nil)
+	defer listResp.Body.Close()
+	listText := string(readBody(t, listResp))
+	if strings.Contains(listText, body.BearerToken) || strings.Contains(listText, body.SigV4.SecretKey) {
+		t.Fatalf("list keys exposed newly generated secret: %s", listText)
+	}
+}
+
+func TestManagementInvalidCreateKeyPayloadReturnsBadRequest(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	cases := []string{
+		`{"display_name":"   ","role":"admin"}`,
+		`{"display_name":"Bad Role","role":"owner"}`,
+	}
+	for _, payload := range cases {
+		resp := env.do(t, http.MethodPost, "/api/management/keys", env.adminToken, strings.NewReader(payload))
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("payload %s status = %d, want %d", payload, resp.StatusCode, http.StatusBadRequest)
+		}
+	}
+}
+
+func TestManagementDeleteKey(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	resp := env.do(t, http.MethodDelete, "/api/management/keys/"+env.memberUserID, env.adminToken, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	if _, err := metadata.NewUserRepository(env.db).GetByID(context.Background(), env.memberUserID); !errorsIsUserNotFound(err) {
+		t.Fatalf("deleted key lookup error = %v, want ErrUserNotFound", err)
+	}
+
+	missing := env.do(t, http.MethodDelete, "/api/management/keys/"+env.memberUserID, env.adminToken, nil)
+	defer missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("delete missing status = %d, want %d", missing.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestManagementAuthRequiresAdmin(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	missingAuth := env.do(t, http.MethodGet, "/api/management/metrics", "", nil)
+	defer missingAuth.Body.Close()
+	if missingAuth.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("missing auth status = %d, want %d", missingAuth.StatusCode, http.StatusUnauthorized)
+	}
+	if missingAuth.Header.Get("WWW-Authenticate") != `Bearer realm="fbs"` {
+		t.Fatalf("WWW-Authenticate = %q", missingAuth.Header.Get("WWW-Authenticate"))
+	}
+
+	member := env.do(t, http.MethodGet, "/api/management/metrics", env.memberToken, nil)
+	defer member.Body.Close()
+	if member.StatusCode != http.StatusForbidden {
+		t.Fatalf("member status = %d, want %d", member.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestManagementCORSPreflight(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/management/keys", nil)
+	req.Header.Set("Origin", "https://dashboard.example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "Authorization, Content-Type")
+	rr := httptest.NewRecorder()
+
+	env.router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://dashboard.example.com" {
+		t.Fatalf("Access-Control-Allow-Origin = %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, http.MethodPost) {
+		t.Fatalf("Access-Control-Allow-Methods = %q, want POST", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "Content-Type") {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want Authorization and Content-Type", got)
+	}
+}
+
+func newManagementTestEnv(t *testing.T) managementTestEnv {
+	t.Helper()
+
+	db, err := metadata.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	ctx := context.Background()
+	userRepo := metadata.NewUserRepository(db)
+	adminToken, _, adminUser, err := auth.CreateBearerToken(ctx, userRepo, "Admin User", "admin")
+	if err != nil {
+		t.Fatalf("create admin token: %v", err)
+	}
+	memberToken, memberSigV4, memberUser, err := auth.CreateBearerToken(ctx, userRepo, "Member User", "member")
+	if err != nil {
+		t.Fatalf("create member token: %v", err)
+	}
+
+	seedManagementHandlerData(t, ctx, db, adminUser.ID)
+
+	bucketRepo := metadata.NewBucketRepository(db)
+	objectRepo := metadata.NewObjectRepository(db)
+	handlers := &management.Handlers{
+		Management: metadata.NewManagementRepository(db),
+		Buckets:    bucketRepo,
+		Objects:    objectRepo,
+		Users:      userRepo,
+	}
+	authChain := &auth.ChainAuthenticator{
+		Authenticators: []auth.Authenticator{
+			&auth.BearerAuthenticator{Repo: userRepo},
+		},
+	}
+
+	cfg := config.Default()
+	cfg.CORSAllowedOrigins = []string{"https://dashboard.example.com"}
+	router := httpapi.NewRouter(cfg, nil, func(r chi.Router) {
+		r.Route("/api/management", func(managementRoutes chi.Router) {
+			managementRoutes.Use(auth.RequireAuthentication(authChain, management.WriteAuthError))
+			managementRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
+			management.RegisterRoutes(managementRoutes, handlers)
+		})
+	})
+
+	return managementTestEnv{
+		router:       router,
+		db:           db,
+		adminToken:   adminToken.RawToken,
+		adminUserID:  adminUser.ID,
+		memberToken:  memberToken.RawToken,
+		memberUserID: memberUser.ID,
+		memberSigV4:  memberSigV4,
+	}
+}
+
+func seedManagementHandlerData(t *testing.T, ctx context.Context, db *sql.DB, ownerID string) {
+	t.Helper()
+
+	bucketRepo := metadata.NewBucketRepository(db)
+	objectRepo := metadata.NewObjectRepository(db)
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+
+	buckets := []*metadata.Bucket{
+		{Name: "photos", OwnerID: ownerID, CreatedAt: now},
+		{Name: "docs", OwnerID: ownerID, CreatedAt: now.Add(time.Second)},
+	}
+	for _, bucket := range buckets {
+		if err := bucketRepo.Create(ctx, bucket); err != nil {
+			t.Fatalf("create bucket: %v", err)
+		}
+	}
+
+	objects := []*metadata.Object{
+		{ID: uuid.NewString(), BucketName: "photos", Key: "2026/image.jpg", Size: 10, ETag: "etag-image", ContentType: "image/jpeg", StoragePath: "hidden/image", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), BucketName: "photos", Key: "2026/raw/a.nef", Size: 20, ETag: "etag-raw-a", ContentType: "image/x-nikon-nef", StoragePath: "hidden/raw-a", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), BucketName: "photos", Key: "2026/raw/b.nef", Size: 30, ETag: "etag-raw-b", ContentType: "image/x-nikon-nef", StoragePath: "hidden/raw-b", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), BucketName: "docs", Key: "readme.txt", Size: 40, ETag: "etag-readme", ContentType: "text/plain", StoragePath: "hidden/readme", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, obj := range objects {
+		if err := objectRepo.Create(ctx, obj); err != nil {
+			t.Fatalf("create object: %v", err)
+		}
+	}
+}
+
+func (e managementTestEnv) do(t *testing.T, method, path, token string, body *strings.Reader) *http.Response {
+	t.Helper()
+
+	var requestBody *strings.Reader
+	if body == nil {
+		requestBody = strings.NewReader("")
+	} else {
+		requestBody = body
+	}
+	req := httptest.NewRequest(method, path, requestBody)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	rr := httptest.NewRecorder()
+	e.router.ServeHTTP(rr, req)
+	return rr.Result()
+}
+
+func decodeResponse(t *testing.T, resp *http.Response, dst interface{}) {
+	t.Helper()
+
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+}
+
+func readBody(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func errorsIsUserNotFound(err error) bool {
+	return err == metadata.ErrUserNotFound
+}

--- a/internal/management/responses.go
+++ b/internal/management/responses.go
@@ -1,0 +1,65 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/i-got-this-faa/fbs/internal/auth"
+)
+
+const (
+	errorCodeInvalidRequest = "invalid_request"
+	errorCodeNotFound       = "not_found"
+	errorCodeUnauthorized   = "unauthorized"
+	errorCodeForbidden      = "forbidden"
+	errorCodeInternal       = "internal_error"
+)
+
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, statusCode int, code, message string) {
+	writeJSON(w, statusCode, errorEnvelope{
+		Error: errorBody{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+func WriteAuthError(w http.ResponseWriter, _ *http.Request, err error) {
+	switch {
+	case errors.Is(err, auth.ErrMissingAuth):
+		w.Header().Set("WWW-Authenticate", `Bearer realm="fbs"`)
+		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "authentication required")
+	case errors.Is(err, auth.ErrUnsupportedScheme),
+		errors.Is(err, auth.ErrMalformedToken),
+		errors.Is(err, auth.ErrInvalidCredentials),
+		errors.Is(err, auth.ErrUnauthorized):
+		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "invalid credentials")
+	case errors.Is(err, auth.ErrInactiveUser), errors.Is(err, auth.ErrForbidden):
+		writeError(w, http.StatusForbidden, errorCodeForbidden, "admin role required")
+	case errors.Is(err, auth.ErrInternal):
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "authentication failed")
+	default:
+		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "invalid credentials")
+	}
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/management/responses.go
+++ b/internal/management/responses.go
@@ -1,8 +1,10 @@
 package management
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -27,9 +29,17 @@ type errorBody struct {
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload interface{}) {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	setJSONHeaders(w)
 	w.WriteHeader(statusCode)
-	_ = json.NewEncoder(w).Encode(payload)
+	if _, err := w.Write(body.Bytes()); err != nil {
+		slog.Warn("write management JSON response", "error", err)
+	}
 }
 
 func writeError(w http.ResponseWriter, statusCode int, code, message string) {
@@ -58,6 +68,16 @@ func WriteAuthError(w http.ResponseWriter, _ *http.Request, err error) {
 	default:
 		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "invalid credentials")
 	}
+}
+
+func setJSONHeaders(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	setNoStoreHeaders(w)
+}
+
+func setNoStoreHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 }
 
 func formatTime(t time.Time) string {

--- a/internal/management/routes.go
+++ b/internal/management/routes.go
@@ -1,0 +1,13 @@
+package management
+
+import "github.com/go-chi/chi/v5"
+
+func RegisterRoutes(r chi.Router, h *Handlers) {
+	r.Get("/metrics", h.Metrics)
+	r.Get("/buckets", h.ListBuckets)
+	r.Get("/buckets/{bucket}/objects", h.ListObjects)
+	r.Get("/buckets/{bucket}/objects/*", h.GetObject)
+	r.Get("/keys", h.ListKeys)
+	r.Post("/keys", h.CreateKey)
+	r.Delete("/keys/{id}", h.DeleteKey)
+}

--- a/internal/metadata/management.go
+++ b/internal/metadata/management.go
@@ -39,11 +39,20 @@ func NewManagementRepository(db *sql.DB) ManagementRepository {
 func (r *sqliteManagementRepository) Metrics(ctx context.Context) (ManagementMetrics, error) {
 	const q = `
 SELECT
-  (SELECT count(*) FROM buckets) AS bucket_count,
-  (SELECT count(*) FROM objects) AS object_count,
-  (SELECT COALESCE(sum(size), 0) FROM objects) AS total_object_bytes,
-  (SELECT count(*) FROM users) AS user_count,
-  (SELECT count(*) FROM users WHERE is_active != 0) AS active_user_count`
+  bucket_stats.bucket_count,
+  object_stats.object_count,
+  object_stats.total_object_bytes,
+  user_stats.user_count,
+  user_stats.active_user_count
+FROM (SELECT count(*) AS bucket_count FROM buckets) bucket_stats
+CROSS JOIN (
+  SELECT count(*) AS object_count, COALESCE(sum(size), 0) AS total_object_bytes
+  FROM objects
+) object_stats
+CROSS JOIN (
+  SELECT count(*) AS user_count, COALESCE(sum(CASE WHEN is_active != 0 THEN 1 ELSE 0 END), 0) AS active_user_count
+  FROM users
+) user_stats`
 
 	var metrics ManagementMetrics
 	if err := r.db.QueryRowContext(ctx, q).Scan(

--- a/internal/metadata/management.go
+++ b/internal/metadata/management.go
@@ -1,0 +1,101 @@
+package metadata
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+type ManagementMetrics struct {
+	BucketCount      int64
+	ObjectCount      int64
+	TotalObjectBytes int64
+	UserCount        int64
+	ActiveUserCount  int64
+}
+
+type BucketSummary struct {
+	Name             string
+	OwnerID          string
+	CreatedAt        time.Time
+	ObjectCount      int64
+	TotalObjectBytes int64
+}
+
+type ManagementRepository interface {
+	Metrics(ctx context.Context) (ManagementMetrics, error)
+	ListBucketSummaries(ctx context.Context) ([]BucketSummary, error)
+}
+
+type sqliteManagementRepository struct {
+	db *sql.DB
+}
+
+func NewManagementRepository(db *sql.DB) ManagementRepository {
+	return &sqliteManagementRepository{db: db}
+}
+
+func (r *sqliteManagementRepository) Metrics(ctx context.Context) (ManagementMetrics, error) {
+	const q = `
+SELECT
+  (SELECT count(*) FROM buckets) AS bucket_count,
+  (SELECT count(*) FROM objects) AS object_count,
+  (SELECT COALESCE(sum(size), 0) FROM objects) AS total_object_bytes,
+  (SELECT count(*) FROM users) AS user_count,
+  (SELECT count(*) FROM users WHERE is_active != 0) AS active_user_count`
+
+	var metrics ManagementMetrics
+	if err := r.db.QueryRowContext(ctx, q).Scan(
+		&metrics.BucketCount,
+		&metrics.ObjectCount,
+		&metrics.TotalObjectBytes,
+		&metrics.UserCount,
+		&metrics.ActiveUserCount,
+	); err != nil {
+		return ManagementMetrics{}, fmt.Errorf("management metrics: %w", err)
+	}
+
+	return metrics, nil
+}
+
+func (r *sqliteManagementRepository) ListBucketSummaries(ctx context.Context) ([]BucketSummary, error) {
+	const q = `
+SELECT b.name, b.owner_id, b.created_at, count(o.id), COALESCE(sum(o.size), 0)
+FROM buckets b
+LEFT JOIN objects o ON o.bucket_name = b.name
+GROUP BY b.name, b.owner_id, b.created_at
+ORDER BY b.created_at ASC`
+
+	rows, err := r.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("list bucket summaries: %w", err)
+	}
+	defer rows.Close()
+
+	var summaries []BucketSummary
+	for rows.Next() {
+		var summary BucketSummary
+		var createdAt string
+		if err := rows.Scan(
+			&summary.Name,
+			&summary.OwnerID,
+			&createdAt,
+			&summary.ObjectCount,
+			&summary.TotalObjectBytes,
+		); err != nil {
+			return nil, fmt.Errorf("list bucket summaries scan: %w", err)
+		}
+		summary.CreatedAt, err = parseTimestamp(createdAt)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, summary)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list bucket summaries rows: %w", err)
+	}
+
+	return summaries, nil
+}

--- a/internal/metadata/management_test.go
+++ b/internal/metadata/management_test.go
@@ -1,0 +1,137 @@
+package metadata
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestManagementRepositoryMetrics(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	seedManagementRepositoryData(t, ctx, db)
+
+	metrics, err := NewManagementRepository(db).Metrics(ctx)
+	if err != nil {
+		t.Fatalf("metrics: %v", err)
+	}
+
+	if metrics.BucketCount != 2 {
+		t.Fatalf("BucketCount = %d, want 2", metrics.BucketCount)
+	}
+	if metrics.ObjectCount != 3 {
+		t.Fatalf("ObjectCount = %d, want 3", metrics.ObjectCount)
+	}
+	if metrics.TotalObjectBytes != 60 {
+		t.Fatalf("TotalObjectBytes = %d, want 60", metrics.TotalObjectBytes)
+	}
+	if metrics.UserCount != 2 {
+		t.Fatalf("UserCount = %d, want 2", metrics.UserCount)
+	}
+	if metrics.ActiveUserCount != 1 {
+		t.Fatalf("ActiveUserCount = %d, want 1", metrics.ActiveUserCount)
+	}
+}
+
+func TestManagementRepositoryListBucketSummaries(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	seedManagementRepositoryData(t, ctx, db)
+
+	summaries, err := NewManagementRepository(db).ListBucketSummaries(ctx)
+	if err != nil {
+		t.Fatalf("list summaries: %v", err)
+	}
+
+	if len(summaries) != 2 {
+		t.Fatalf("len(summaries) = %d, want 2", len(summaries))
+	}
+	if summaries[0].Name != "photos" {
+		t.Fatalf("first bucket = %q, want photos", summaries[0].Name)
+	}
+	if summaries[0].ObjectCount != 2 || summaries[0].TotalObjectBytes != 30 {
+		t.Fatalf("photos summary = count %d bytes %d, want count 2 bytes 30", summaries[0].ObjectCount, summaries[0].TotalObjectBytes)
+	}
+	if summaries[1].Name != "docs" {
+		t.Fatalf("second bucket = %q, want docs", summaries[1].Name)
+	}
+	if summaries[1].ObjectCount != 1 || summaries[1].TotalObjectBytes != 30 {
+		t.Fatalf("docs summary = count %d bytes %d, want count 1 bytes 30", summaries[1].ObjectCount, summaries[1].TotalObjectBytes)
+	}
+}
+
+func seedManagementRepositoryData(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	userRepo := NewUserRepository(db)
+	bucketRepo := NewBucketRepository(db)
+	objectRepo := NewObjectRepository(db)
+	now := time.Date(2026, 5, 8, 12, 0, 0, 0, time.UTC)
+
+	users := []*User{
+		{
+			ID:          "admin-user",
+			DisplayName: "Admin",
+			AccessKeyID: "fbsa_admin",
+			SecretHash:  "hash1",
+			Role:        "admin",
+			IsActive:    true,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+		{
+			ID:          "member-user",
+			DisplayName: "Member",
+			AccessKeyID: "fbsa_member",
+			SecretHash:  "hash2",
+			Role:        "member",
+			IsActive:    false,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		},
+	}
+	for _, user := range users {
+		if err := userRepo.Create(ctx, user); err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+
+	buckets := []*Bucket{
+		{Name: "photos", OwnerID: "admin-user", CreatedAt: now},
+		{Name: "docs", OwnerID: "member-user", CreatedAt: now.Add(time.Second)},
+	}
+	for _, bucket := range buckets {
+		if err := bucketRepo.Create(ctx, bucket); err != nil {
+			t.Fatalf("create bucket: %v", err)
+		}
+	}
+
+	objects := []*Object{
+		{ID: uuid.NewString(), BucketName: "photos", Key: "a.jpg", Size: 10, ETag: "etag-a", ContentType: "image/jpeg", StoragePath: "photos/a.jpg", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), BucketName: "photos", Key: "b.jpg", Size: 20, ETag: "etag-b", ContentType: "image/jpeg", StoragePath: "photos/b.jpg", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.NewString(), BucketName: "docs", Key: "c.txt", Size: 30, ETag: "etag-c", ContentType: "text/plain", StoragePath: "docs/c.txt", CreatedAt: now, UpdatedAt: now},
+	}
+	for _, obj := range objects {
+		if err := objectRepo.Create(ctx, obj); err != nil {
+			t.Fatalf("create object: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the F10 JSON management API under `/api/management` for dashboard metrics, bucket/object browsing, object metadata, and key management.

Adds a SQL-backed management metadata repository for aggregate metrics and bucket summaries, plus admin-only bearer/dev auth wiring before the broad S3 routes.

Closes #12

## Validation

- `go test ./...`