### PR TITLE
Implement mini-IAM resource grants

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -112,12 +112,16 @@ func main() {
 		}
 	}
 
+	grantRepo := metadata.NewGrantRepository(db)
+	authzEvaluator := s3.NewAuthzEvaluator(grantRepo)
+
 	managementHandlers := &management.Handlers{
 		Management:       metadata.NewManagementRepository(db),
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
 		Activity:         metadata.NewActivityRepository(db),
 		Users:            userRepo,
+		Grants:           grantRepo,
 		Storage:          storageEngine,
 		Config:           cfg,
 		PublicReadSigner: publicReadSigner,
@@ -127,6 +131,8 @@ func main() {
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
 		Activity:         metadata.NewActivityRepository(db),
+		Grants:           grantRepo,
+		Authz:            authzEvaluator,
 		Storage:          storageEngine,
 		Logger:           logger,
 		S3CacheControl:   cfg.S3CacheControl,
@@ -156,8 +162,12 @@ func main() {
 		setup.RegisterRoutes(r, setupHandlers)
 		r.Route("/api/management", func(managementRoutes chi.Router) {
 			managementRoutes.Use(auth.RequireAuthentication(managementAuthChain, management.WriteAuthError))
-			managementRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
-			management.RegisterRoutes(managementRoutes, managementHandlers)
+			// Grant routes: authenticated admin or bucket owner (enforced in handlers).
+			management.RegisterGrantRoutes(managementRoutes, managementHandlers)
+			managementRoutes.Group(func(adminRoutes chi.Router) {
+				adminRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
+				management.RegisterAdminRoutes(adminRoutes, managementHandlers)
+			})
 		})
 		r.Group(func(s3Routes chi.Router) {
 			s3Routes.Use(auth.RequireAuthentication(authChain, writeS3AuthError))

--- a/compat/s3-tests/report.sh
+++ b/compat/s3-tests/report.sh
@@ -124,6 +124,20 @@ log_path, collect_path, out_dir = map(Path, sys.argv[1:4])
 log = log_path.read_text(errors="replace")
 selected = [ln.strip() for ln in collect_path.read_text().splitlines() if ln.startswith("s3tests/")]
 
+# Prefer a repo-relative path in generated artifacts (no local home dirs).
+def portable_log_label(p: Path) -> str:
+    try:
+        abs_p = p.resolve()
+        text = str(abs_p)
+        marker = "/compat/s3-tests/"
+        if marker in text:
+            return "compat/s3-tests/" + text.split(marker, 1)[1]
+        return p.name
+    except Exception:
+        return p.name
+
+log_label = portable_log_label(log_path)
+
 failed, errored = set(), set()
 for line in log.splitlines():
     if line.startswith("FAILED s3tests/"):
@@ -206,7 +220,7 @@ now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 md = [
     "# S3 Compatibility Checklist",
     "",
-    f"Generated from `{log_path}` ({now}).",
+    f"Generated from `{log_label}` ({now}).",
     "",
     "Source: ceph/s3-tests functional suite with `markers.core` filter.",
     "",
@@ -274,7 +288,7 @@ ul{list-style:none;padding:0} li{font-family:ui-monospace,monospace;font-size:.8
 .badge{font-size:.75rem;background:#eee;border-radius:999px;padding:.1rem .45rem;margin-left:.4rem}
 </style></head><body>""",
     "<h1>fbs-core S3 compatibility checklist</h1>",
-    f"<p>From <code>{log_path}</code> · {now}</p>",
+    f"<p>From <code>{log_label}</code> · {now}</p>",
     f"<p><strong class=pass>{len(passed)} passed</strong> · <strong class=fail>{len(failed_m)} failed</strong> · <strong class=err>{len(errored_m)} errors</strong> · {len(selected)} selected ({100*len(passed)/max(len(selected),1):.1f}%)</p>",
     "<table><tr><th>Feature</th><th>Pass</th><th>Fail</th><th>Err</th><th>Rate</th><th>Coverage</th></tr>",
 ]

--- a/compat/s3-tests/results/checklist.html
+++ b/compat/s3-tests/results/checklist.html
@@ -12,7 +12,7 @@ ul{list-style:none;padding:0} li{font-family:ui-monospace,monospace;font-size:.8
 .badge{font-size:.75rem;background:#eee;border-radius:999px;padding:.1rem .45rem;margin-left:.4rem}
 </style></head><body>
 <h1>fbs-core S3 compatibility checklist</h1>
-<p>From <code>/home/radhey/code/fbs/fbs-core/compat/s3-tests/results/last-run.log</code> · 2026-07-11 07:10 UTC</p>
+<p>From <code>compat/s3-tests/results/last-run.log</code> · 2026-07-11 07:10 UTC</p>
 <p><strong class=pass>150 passed</strong> · <strong class=fail>291 failed</strong> · <strong class=err>2 errors</strong> · 443 selected (33.9%)</p>
 <table><tr><th>Feature</th><th>Pass</th><th>Fail</th><th>Err</th><th>Rate</th><th>Coverage</th></tr>
 <tr><td>Bucket Ops</td><td class='num pass'>13</td><td class='num fail'>5</td><td class='num err'>0</td><td class=num>72%</td><td><div class=bar><span style='width:72.2%'></span></div></td></tr>

--- a/compat/s3-tests/results/checklist.html
+++ b/compat/s3-tests/results/checklist.html
@@ -12,7 +12,7 @@ ul{list-style:none;padding:0} li{font-family:ui-monospace,monospace;font-size:.8
 .badge{font-size:.75rem;background:#eee;border-radius:999px;padding:.1rem .45rem;margin-left:.4rem}
 </style></head><body>
 <h1>fbs-core S3 compatibility checklist</h1>
-<p>From <code>/tmp/s3-tests-run2.log</code> · 2026-07-10 09:31 UTC</p>
+<p>From <code>/home/radhey/code/fbs/fbs-core/compat/s3-tests/results/last-run.log</code> · 2026-07-11 07:10 UTC</p>
 <p><strong class=pass>150 passed</strong> · <strong class=fail>291 failed</strong> · <strong class=err>2 errors</strong> · 443 selected (33.9%)</p>
 <table><tr><th>Feature</th><th>Pass</th><th>Fail</th><th>Err</th><th>Rate</th><th>Coverage</th></tr>
 <tr><td>Bucket Ops</td><td class='num pass'>13</td><td class='num fail'>5</td><td class='num err'>0</td><td class=num>72%</td><td><div class=bar><span style='width:72.2%'></span></div></td></tr>

--- a/compat/s3-tests/results/checklist.md
+++ b/compat/s3-tests/results/checklist.md
@@ -1,6 +1,6 @@
 # S3 Compatibility Checklist
 
-Generated from `/tmp/s3-tests-run2.log` (2026-07-10 09:31 UTC).
+Generated from `/home/radhey/code/fbs/fbs-core/compat/s3-tests/results/last-run.log` (2026-07-11 07:10 UTC).
 
 Source: ceph/s3-tests functional suite with `markers.core` filter.
 

--- a/compat/s3-tests/results/checklist.md
+++ b/compat/s3-tests/results/checklist.md
@@ -1,6 +1,6 @@
 # S3 Compatibility Checklist
 
-Generated from `/home/radhey/code/fbs/fbs-core/compat/s3-tests/results/last-run.log` (2026-07-11 07:10 UTC).
+Generated from `compat/s3-tests/results/last-run.log` (2026-07-11 07:10 UTC).
 
 Source: ceph/s3-tests functional suite with `markers.core` filter.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,7 @@ The authentication chain supports:
 - AWS SigV4 header authentication.
 - AWS SigV4 query-string authentication.
 
-Authenticated requests receive an `auth.Principal` in request context. S3 uses the principal for ownership and list filtering. Management requires `Role == "admin"`.
+Authenticated requests receive an `auth.Principal` in request context. S3 uses the principal for ownership, grant evaluation, and list filtering. Most Management endpoints require `Role == "admin"`; grant administration and ownership transfer allow the bucket owner, and `GET /api/management/grants/me` is available to any authenticated principal.
 
 ## Caching And File Serving
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,10 +5,11 @@
 - `cmd/server`: process entrypoint, wiring, startup reconciliation, background cleanup, and graceful shutdown.
 - `internal/http`: router construction, health endpoints, CORS, logging, and panic recovery middleware.
 - `internal/auth`: Bearer token, AWS SigV4, dev-mode authentication, role middleware, and request principal context.
+- `internal/authz`: pure S3 data-plane allow/deny evaluation (admin → owner → resource grants → deny).
 - `internal/setup`: loopback-only first-start bootstrap endpoints.
-- `internal/management`: admin JSON API handlers.
+- `internal/management`: admin JSON API handlers, plus grant and ownership routes for admins/owners.
 - `internal/s3`: S3-compatible bucket, object, copy, delete, list, public read, and multipart handlers.
-- `internal/metadata`: SQLite-backed repositories and optional metadata cache wrappers.
+- `internal/metadata`: SQLite-backed repositories (including grants) and optional metadata cache wrappers.
 - `internal/storage`: local disk object storage, path validation, atomic writes, reads, deletes, and reconciliation.
 - `migrations`: runtime SQLite migrations.
 
@@ -39,9 +40,9 @@ The router always registers:
 - `/api/management/*`
 - S3 bucket and object routes at the root
 
-Management routes are protected by authentication and then by `admin` role authorization.
+Management routes require authentication. Most management endpoints also require the `admin` role. Grant administration and ownership transfer are available to admins or the bucket owner; `GET /api/management/grants/me` is available to any authenticated principal for their own grants.
 
-S3 routes are protected by authentication and then dispatched based on method, bucket, object key, and query parameters. The object read routes are registered separately from mutation routes so reads can keep a minimal middleware path and preserve Go's efficient file-serving behavior.
+S3 routes are protected by authentication and then authorized per action through `internal/authz` (admin short-circuit, bucket owner short-circuit, then active resource grants with optional key prefix). Handlers map operations to fixed `s3:*` actions; they do not embed authorization SQL. The object read routes are registered separately from mutation routes so reads can keep a minimal middleware path and preserve Go's efficient file-serving behavior.
 
 ## Data Model
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -66,16 +66,26 @@ The test suite is package-focused and covers:
 - Setup bootstrap behavior.
 - Management endpoint contracts.
 - Bearer, SigV4, dev-mode, principal, and middleware auth behavior.
-- Metadata repositories, migrations, cache behavior, multipart state, users, buckets, objects, and management queries.
+- Authz evaluator (admin/owner/grants/prefix/list rules) and grant repository behavior.
+- Metadata repositories, migrations, cache behavior, multipart state, users, buckets, objects, grants, and management queries.
 - Storage writes, reads, deletes, path sanitization, and reconciliation.
-- S3 bucket, object, multipart, checksum, and compatibility behavior.
+- S3 bucket, object, multipart, checksum, grant-scoped access, and compatibility behavior.
 - Public read signing.
+
+## Adding S3 Operations and Actions
+
+When implementing a new S3 data-plane operation:
+
+1. Map it to an existing action in `internal/authz/actions.go`, or add a new action there and in `plan/access-control/access-control.md`.
+2. If the action should be grantable, add it to `GrantableActions` and to metadata grantable validation.
+3. Call the shared authz evaluator from the handler with the correct action, bucket, object key, and list prefix.
+4. Do not invent a private owner-only boolean path for normal bucket/object ops.
 
 ## Implementation Principles
 
 The codebase keeps behavior separated by package:
 
-- HTTP handlers translate protocol details to repository and storage calls.
+- HTTP handlers translate protocol details to repository and storage calls; authorization decisions come from `internal/authz`.
 - Metadata repositories own SQLite queries and transactional state changes.
 - Storage owns filesystem paths, temp files, file assembly, and reconciliation.
 - Auth owns credential parsing and principal creation.

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -1,6 +1,6 @@
 # Management API
 
-The Management API is a JSON admin API under `/api/management`. All routes require authentication and the `admin` role. Responses use `Cache-Control: no-store`.
+The Management API is a JSON API under `/api/management`. Most routes require authentication and the `admin` role. Grant administration and ownership transfer also allow the **bucket owner**. Listing one's own grants (`GET /grants/me`) requires only authentication. Responses use `Cache-Control: no-store`.
 
 Errors use this shape:
 
@@ -29,7 +29,77 @@ Missing credentials return `401` and set:
 WWW-Authenticate: Bearer realm="fbs"
 ```
 
-Malformed, invalid, or unsupported credentials return `401`. Inactive users or non-admin users return `403`.
+Malformed, invalid, or unsupported credentials return `401`. Inactive users or callers without the required role return `403`.
+
+## Resource Grants (mini-IAM)
+
+Normalized resource grants are the sharing model for S3 data-plane access. They are **not** AWS IAM policies, bucket policies, or ACLs. See `plan/access-control/access-control.md`.
+
+List grants on a bucket (admin or owner):
+
+```http
+GET /api/management/buckets/{bucket}/grants
+```
+
+Create grants (admin or owner). One row is created per action; duplicate active grants are idempotent:
+
+```http
+POST /api/management/buckets/{bucket}/grants
+Content-Type: application/json
+
+{
+  "grantee_user_id": "user-uuid",
+  "actions": ["s3:GetObject", "s3:ListBucket"],
+  "key_prefix": "docs/",
+  "note": "optional label"
+}
+```
+
+Alternatively identify the grantee with `grantee_access_key_id` (resolved server-side to user id). Grantable actions:
+
+- `s3:ListBucket`
+- `s3:GetObject`
+- `s3:PutObject`
+- `s3:DeleteObject`
+- `s3:ListMultipartUploadParts`
+- `s3:AbortMultipartUpload`
+
+`s3:CreateBucket` and `s3:DeleteBucket` are not grantable.
+
+Update a grant (prefix, active, note):
+
+```http
+PATCH /api/management/buckets/{bucket}/grants/{grantID}
+```
+
+Delete a grant:
+
+```http
+DELETE /api/management/buckets/{bucket}/grants/{grantID}
+```
+
+List my grants:
+
+```http
+GET /api/management/grants/me
+```
+
+List grants for a user (admin only):
+
+```http
+GET /api/management/users/{userID}/grants
+```
+
+Transfer bucket ownership (admin or current owner):
+
+```http
+POST /api/management/buckets/{bucket}/transfer-ownership
+Content-Type: application/json
+
+{
+  "new_owner_user_id": "user-uuid"
+}
+```
 
 ## Metrics
 

--- a/docs/s3-api.md
+++ b/docs/s3-api.md
@@ -4,18 +4,22 @@ The S3-compatible API is rooted at `/`. Protected S3 routes accept Bearer tokens
 
 The implemented region is `us-east-1`.
 
+## Authorization
+
+After authentication, each data-plane operation is authorized through a fixed action catalog (`s3:ListBucket`, `s3:GetObject`, `s3:PutObject`, and related actions). Evaluation order is: **admin** → **bucket owner** → **active resource grant** (optional key prefix) → **deny**. Denied calls return S3 `AccessDenied`. Grants are managed via the Management API, not via S3 `?acl` or `?policy` (those remain unsupported). See `plan/access-control/access-control.md`.
+
 ## Supported Bucket Operations
 
 | Operation | Request | Notes |
 | --- | --- | --- |
-| List buckets | `GET /` | Admins see all buckets. Members see owned buckets. |
-| Create bucket | `PUT /{bucket}` | Empty body or `CreateBucketConfiguration` with empty or `us-east-1` location. |
-| Head bucket | `HEAD /{bucket}` | Returns existence/authorization-compatible S3 response. |
-| Get bucket location | `GET /{bucket}?location` | Returns region information. |
-| List objects v1 | `GET /{bucket}` or `GET /{bucket}?list-type=1` | Supports `prefix`, `delimiter`, `marker`, `max-keys`, `encoding-type=url`. |
-| List objects v2 | `GET /{bucket}?list-type=2` | Supports `prefix`, `delimiter`, `start-after`, `continuation-token`, `max-keys`, `encoding-type=url`. |
-| Delete bucket | `DELETE /{bucket}` | Requires bucket to be empty. |
-| Delete objects | `POST /{bucket}?delete` (also `DELETE /{bucket}?delete`) | Deletes up to 1000 objects from an XML request body. AWS clients use POST. |
+| List buckets | `GET /` | Admins see all buckets. Members see owned buckets plus any bucket with an active grant. |
+| Create bucket | `PUT /{bucket}` | Empty body or `CreateBucketConfiguration` with empty or `us-east-1` location. Any authenticated user may create; becomes owner. |
+| Head bucket | `HEAD /{bucket}` | Requires `s3:ListBucket` (or owner/admin). |
+| Get bucket location | `GET /{bucket}?location` | Requires `s3:ListBucket` (or owner/admin). |
+| List objects v1 | `GET /{bucket}` or `GET /{bucket}?list-type=1` | Requires `s3:ListBucket`; supports `prefix`, `delimiter`, `marker`, `max-keys`, `encoding-type=url`. |
+| List objects v2 | `GET /{bucket}?list-type=2` | Requires `s3:ListBucket`; supports `prefix`, `delimiter`, `start-after`, `continuation-token`, `max-keys`, `encoding-type=url`. |
+| Delete bucket | `DELETE /{bucket}` | Admin or owner only; not grantable. Requires bucket to be empty. |
+| Delete objects | `POST /{bucket}?delete` (also `DELETE /{bucket}?delete`) | Each key authorized for `s3:DeleteObject`; denied keys reported as errors when not quiet. AWS clients use POST. |
 
 ## Supported Object Operations
 

--- a/docs/s3-api.md
+++ b/docs/s3-api.md
@@ -19,7 +19,7 @@ After authentication, each data-plane operation is authorized through a fixed ac
 | List objects v1 | `GET /{bucket}` or `GET /{bucket}?list-type=1` | Requires `s3:ListBucket`; supports `prefix`, `delimiter`, `marker`, `max-keys`, `encoding-type=url`. |
 | List objects v2 | `GET /{bucket}?list-type=2` | Requires `s3:ListBucket`; supports `prefix`, `delimiter`, `start-after`, `continuation-token`, `max-keys`, `encoding-type=url`. |
 | Delete bucket | `DELETE /{bucket}` | Admin or owner only; not grantable. Requires bucket to be empty. |
-| Delete objects | `POST /{bucket}?delete` (also `DELETE /{bucket}?delete`) | Each key authorized for `s3:DeleteObject`; denied keys reported as errors when not quiet. AWS clients use POST. |
+| Delete objects | `POST /{bucket}?delete` (also `DELETE /{bucket}?delete`) | Each key authorized for `s3:DeleteObject`; denied keys are always returned as per-key errors. Quiet mode suppresses only successful `<Deleted>` entries. AWS clients use POST. |
 
 ## Supported Object Operations
 

--- a/docs/setup-and-authentication.md
+++ b/docs/setup-and-authentication.md
@@ -103,7 +103,7 @@ Users have one of two roles:
 
 Shared-bucket access is configured via Management resource grants (mini-IAM), not AWS IAM policies or S3 ACLs. See `plan/access-control/access-control.md` and `docs/management-api.md`.
 
-S3 bucket listing is role-aware. Admin users list all buckets. Member users list only buckets owned by their user ID.
+S3 bucket listing is role-aware. Admin users list all buckets. Member users list buckets they own plus any bucket on which they hold at least one active resource grant (any action).
 
 ## Inactive Users
 

--- a/docs/setup-and-authentication.md
+++ b/docs/setup-and-authentication.md
@@ -98,8 +98,10 @@ Rules:
 
 Users have one of two roles:
 
-- `admin`: can use S3 routes and Management API routes.
-- `member`: can use S3 routes. Management API access is denied.
+- `admin`: full S3 data-plane access and full Management API access (including grant administration on any bucket).
+- `member`: S3 access on owned buckets and buckets/actions/prefixes covered by **resource grants**. No general Management access; may list own grants (`GET /api/management/grants/me`) and administer grants only as owner of a bucket.
+
+Shared-bucket access is configured via Management resource grants (mini-IAM), not AWS IAM policies or S3 ACLs. See `plan/access-control/access-control.md` and `docs/management-api.md`.
 
 S3 bucket listing is role-aware. Admin users list all buckets. Member users list only buckets owned by their user ID.
 

--- a/internal/authz/actions.go
+++ b/internal/authz/actions.go
@@ -1,0 +1,42 @@
+package authz
+
+// Action names for S3 data-plane authorization. Handlers map protocol
+// operations to these names; grants and the evaluator speak only these names.
+const (
+	ActionCreateBucket             = "s3:CreateBucket"
+	ActionDeleteBucket             = "s3:DeleteBucket"
+	ActionListBucket               = "s3:ListBucket"
+	ActionGetObject                = "s3:GetObject"
+	ActionPutObject                = "s3:PutObject"
+	ActionDeleteObject             = "s3:DeleteObject"
+	ActionListMultipartUploadParts = "s3:ListMultipartUploadParts"
+	ActionAbortMultipartUpload     = "s3:AbortMultipartUpload"
+)
+
+// GrantableActions is the set accepted by grant create/update APIs.
+var GrantableActions = map[string]struct{}{
+	ActionListBucket:               {},
+	ActionGetObject:                {},
+	ActionPutObject:                {},
+	ActionDeleteObject:             {},
+	ActionListMultipartUploadParts: {},
+	ActionAbortMultipartUpload:     {},
+}
+
+// IsGrantable reports whether action may appear on a grant row.
+func IsGrantable(action string) bool {
+	_, ok := GrantableActions[action]
+	return ok
+}
+
+// AllDataPlaneActions lists every action the evaluator understands for S3.
+var AllDataPlaneActions = []string{
+	ActionCreateBucket,
+	ActionDeleteBucket,
+	ActionListBucket,
+	ActionGetObject,
+	ActionPutObject,
+	ActionDeleteObject,
+	ActionListMultipartUploadParts,
+	ActionAbortMultipartUpload,
+}

--- a/internal/authz/evaluator.go
+++ b/internal/authz/evaluator.go
@@ -1,0 +1,103 @@
+package authz
+
+import (
+	"context"
+	"strings"
+
+	"github.com/i-got-this-faa/fbs/internal/auth"
+)
+
+// DecisionRequest is the input to authorization evaluation.
+type DecisionRequest struct {
+	Principal  auth.Principal
+	Action     string
+	Bucket     string
+	ObjectKey  string
+	// ListPrefix is the list API prefix query value. Used only for s3:ListBucket.
+	ListPrefix string
+	// BucketOwnerID is the owner of Bucket when the bucket exists.
+	// Empty when the operation does not target an existing bucket (CreateBucket).
+	BucketOwnerID string
+}
+
+// GrantStore loads active grants for evaluation. Implementations must not
+// return inactive grants (or must mark them Active=false).
+type GrantStore interface {
+	ListActiveForGranteeBucket(ctx context.Context, granteeUserID, bucketName string) ([]Grant, error)
+}
+
+// Evaluator decides allow/deny for S3 data-plane actions.
+// It does not write HTTP responses and does not depend on net/http.
+type Evaluator struct {
+	Grants GrantStore
+}
+
+// Allow evaluates the request and returns whether access is permitted.
+// Store errors are returned to the caller; callers must fail closed (deny or 5xx).
+func (e *Evaluator) Allow(ctx context.Context, req DecisionRequest) (bool, error) {
+	if strings.TrimSpace(req.Principal.UserID) == "" {
+		return false, nil
+	}
+	if strings.TrimSpace(req.Action) == "" {
+		return false, nil
+	}
+
+	// 1. System admin short-circuit.
+	if req.Principal.Role == "admin" {
+		return true, nil
+	}
+
+	// CreateBucket: any authenticated principal may create; not grant-based.
+	if req.Action == ActionCreateBucket {
+		return true, nil
+	}
+
+	// Operations on an existing bucket require a bucket identity.
+	if strings.TrimSpace(req.Bucket) == "" {
+		return false, nil
+	}
+
+	// 2. Bucket owner short-circuit (including DeleteBucket).
+	if req.BucketOwnerID != "" && req.BucketOwnerID == req.Principal.UserID {
+		return true, nil
+	}
+
+	// DeleteBucket is never grantable.
+	if req.Action == ActionDeleteBucket {
+		return false, nil
+	}
+
+	// 3. Matching active grant.
+	if e == nil || e.Grants == nil {
+		return false, nil
+	}
+
+	grants, err := e.Grants.ListActiveForGranteeBucket(ctx, req.Principal.UserID, req.Bucket)
+	if err != nil {
+		return false, err
+	}
+
+	for _, grant := range grants {
+		if !grant.Active {
+			continue
+		}
+		if grant.Action != req.Action {
+			continue
+		}
+		if grantMatches(grant, req) {
+			return true, nil
+		}
+	}
+
+	// 4. Default deny.
+	return false, nil
+}
+
+func grantMatches(grant Grant, req DecisionRequest) bool {
+	switch req.Action {
+	case ActionListBucket:
+		return ListPrefixCovered(grant.KeyPrefix, req.ListPrefix)
+	default:
+		return PrefixMatches(grant.KeyPrefix, req.ObjectKey)
+	}
+}

--- a/internal/authz/evaluator_test.go
+++ b/internal/authz/evaluator_test.go
@@ -1,0 +1,241 @@
+package authz_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/authz"
+)
+
+type staticGrantStore struct {
+	grants []authz.Grant
+	err    error
+}
+
+func (s staticGrantStore) ListActiveForGranteeBucket(_ context.Context, granteeUserID, bucketName string) ([]authz.Grant, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	var out []authz.Grant
+	for _, g := range s.grants {
+		if g.GranteeUserID == granteeUserID && g.BucketName == bucketName && g.Active {
+			out = append(out, g)
+		}
+	}
+	return out, nil
+}
+
+func TestEvaluatorAdminAllow(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal:     auth.Principal{UserID: "admin", Role: "admin"},
+		Action:        authz.ActionGetObject,
+		Bucket:        "any",
+		ObjectKey:     "k",
+		BucketOwnerID: "other",
+	})
+	if err != nil || !ok {
+		t.Fatalf("allow = %v err = %v, want true", ok, err)
+	}
+}
+
+func TestEvaluatorOwnerAllow(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal:     auth.Principal{UserID: "owner", Role: "member"},
+		Action:        authz.ActionDeleteBucket,
+		Bucket:        "b",
+		BucketOwnerID: "owner",
+	})
+	if err != nil || !ok {
+		t.Fatalf("allow = %v err = %v, want true", ok, err)
+	}
+}
+
+func TestEvaluatorOwnerDenyForeignWithoutGrant(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal:     auth.Principal{UserID: "member", Role: "member"},
+		Action:        authz.ActionGetObject,
+		Bucket:        "b",
+		ObjectKey:     "k",
+		BucketOwnerID: "other",
+	})
+	if err != nil || ok {
+		t.Fatalf("allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorGranteeAllowExactAction(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{{
+		BucketName: "b", GranteeUserID: "g", Action: authz.ActionGetObject, KeyPrefix: "", Active: true,
+	}}}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal:     auth.Principal{UserID: "g", Role: "member"},
+		Action:        authz.ActionGetObject,
+		Bucket:        "b",
+		ObjectKey:     "docs/a.txt",
+		BucketOwnerID: "owner",
+	})
+	if err != nil || !ok {
+		t.Fatalf("allow = %v err = %v, want true", ok, err)
+	}
+}
+
+func TestEvaluatorGranteeDenyWrongAction(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{{
+		BucketName: "b", GranteeUserID: "g", Action: authz.ActionGetObject, KeyPrefix: "", Active: true,
+	}}}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal:     auth.Principal{UserID: "g", Role: "member"},
+		Action:        authz.ActionPutObject,
+		Bucket:        "b",
+		ObjectKey:     "docs/a.txt",
+		BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorPrefixMatchAndMismatch(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{{
+		BucketName: "b", GranteeUserID: "g", Action: authz.ActionPutObject, KeyPrefix: "uploads/", Active: true,
+	}}}}
+
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionPutObject, Bucket: "b", ObjectKey: "uploads/a.txt", BucketOwnerID: "owner",
+	})
+	if err != nil || !ok {
+		t.Fatalf("prefix match allow = %v err = %v", ok, err)
+	}
+
+	ok, err = eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionPutObject, Bucket: "b", ObjectKey: "other/a.txt", BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("prefix mismatch allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorInactiveGrantIgnored(t *testing.T) {
+	t.Parallel()
+	// Store contract: only active grants returned. Also ensure Active=false is ignored if present.
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{{
+		BucketName: "b", GranteeUserID: "g", Action: authz.ActionGetObject, KeyPrefix: "", Active: false,
+	}}}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionGetObject, Bucket: "b", ObjectKey: "k", BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorCreateBucketAuthenticatedMember(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "m", Role: "member"},
+		Action:    authz.ActionCreateBucket,
+	})
+	if err != nil || !ok {
+		t.Fatalf("allow = %v err = %v, want true", ok, err)
+	}
+}
+
+func TestEvaluatorDeleteBucketDeniedForGrantee(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{
+		{BucketName: "b", GranteeUserID: "g", Action: authz.ActionGetObject, Active: true},
+		{BucketName: "b", GranteeUserID: "g", Action: authz.ActionPutObject, Active: true},
+		{BucketName: "b", GranteeUserID: "g", Action: authz.ActionDeleteObject, Active: true},
+		{BucketName: "b", GranteeUserID: "g", Action: authz.ActionListBucket, Active: true},
+	}}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionDeleteBucket, Bucket: "b", BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorListBucketPrefixRules(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{grants: []authz.Grant{{
+		BucketName: "b", GranteeUserID: "g", Action: authz.ActionListBucket, KeyPrefix: "docs/", Active: true,
+	}}}}
+
+	// Can list under grant prefix.
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionListBucket, Bucket: "b", ListPrefix: "docs/", BucketOwnerID: "owner",
+	})
+	if err != nil || !ok {
+		t.Fatalf("list covered allow = %v err = %v", ok, err)
+	}
+
+	// Cannot list whole bucket with empty request prefix.
+	ok, err = eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionListBucket, Bucket: "b", ListPrefix: "", BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("list empty prefix allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestEvaluatorStoreErrorDoesNotAllow(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{err: errors.New("db down")}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionGetObject, Bucket: "b", ObjectKey: "k", BucketOwnerID: "owner",
+	})
+	if err == nil || ok {
+		t.Fatalf("allow = %v err = %v, want false with error", ok, err)
+	}
+}
+
+func TestEvaluatorDefaultDenyNoGrants(t *testing.T) {
+	t.Parallel()
+	eval := &authz.Evaluator{Grants: staticGrantStore{}}
+	ok, err := eval.Allow(context.Background(), authz.DecisionRequest{
+		Principal: auth.Principal{UserID: "g", Role: "member"},
+		Action:    authz.ActionGetObject, Bucket: "b", ObjectKey: "k", BucketOwnerID: "owner",
+	})
+	if err != nil || ok {
+		t.Fatalf("allow = %v err = %v, want false", ok, err)
+	}
+}
+
+func TestPrefixMatches(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		prefix, key string
+		want        bool
+	}{
+		{"", "any", true},
+		{"docs/", "docs/", true},
+		{"docs/", "docs/a", true},
+		{"docs/", "doc", false},
+		{"docs/", "other", false},
+	}
+	for _, tc := range cases {
+		if got := authz.PrefixMatches(tc.prefix, tc.key); got != tc.want {
+			t.Fatalf("PrefixMatches(%q,%q)=%v want %v", tc.prefix, tc.key, got, tc.want)
+		}
+	}
+}

--- a/internal/authz/grant.go
+++ b/internal/authz/grant.go
@@ -1,0 +1,47 @@
+package authz
+
+// Grant is the authorization view of a persisted resource grant.
+// Metadata repositories map store rows into this shape.
+type Grant struct {
+	BucketName    string
+	GranteeUserID string
+	Action        string
+	KeyPrefix     string
+	Active        bool
+}
+
+// PrefixMatches reports whether objectKey is covered by grantPrefix.
+// Empty grantPrefix matches the entire keyspace. Matching is a literal string
+// prefix: key equals prefix, or key starts with prefix.
+func PrefixMatches(grantPrefix, objectKey string) bool {
+	if grantPrefix == "" {
+		return true
+	}
+	if objectKey == grantPrefix {
+		return true
+	}
+	return len(objectKey) > len(grantPrefix) && objectKey[:len(grantPrefix)] == grantPrefix
+}
+
+// ListPrefixCovered reports whether a ListBucket request prefix is covered by
+// a grant prefix. Callers may narrow into a subtree they can already list, not
+// widen outside it.
+//
+// Covered means:
+//   - grant prefix is empty (whole-bucket list grant), or
+//   - request prefix equals grant prefix, or
+//   - request prefix extends grant prefix (starts with grant prefix)
+//
+// An empty request prefix is only covered by an empty grant prefix.
+func ListPrefixCovered(grantPrefix, requestPrefix string) bool {
+	if grantPrefix == "" {
+		return true
+	}
+	if requestPrefix == "" {
+		return false
+	}
+	if requestPrefix == grantPrefix {
+		return true
+	}
+	return len(requestPrefix) > len(grantPrefix) && requestPrefix[:len(grantPrefix)] == grantPrefix
+}

--- a/internal/authz/store_adapter.go
+++ b/internal/authz/store_adapter.go
@@ -1,0 +1,14 @@
+package authz
+
+import "context"
+
+// FuncStore adapts a function to GrantStore.
+type FuncStore func(ctx context.Context, granteeUserID, bucketName string) ([]Grant, error)
+
+// ListActiveForGranteeBucket implements GrantStore.
+func (f FuncStore) ListActiveForGranteeBucket(ctx context.Context, granteeUserID, bucketName string) ([]Grant, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return f(ctx, granteeUserID, bucketName)
+}

--- a/internal/management/grants.go
+++ b/internal/management/grants.go
@@ -187,6 +187,10 @@ func (h *Handlers) PatchBucketGrant(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid or non-grantable action")
 			return
 		}
+		if errors.Is(err, metadata.ErrDuplicateGrant) {
+			writeError(w, http.StatusConflict, errorCodeInvalidRequest, "an active grant already exists for this bucket, grantee, action, and prefix")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to update grant")
 		return
 	}

--- a/internal/management/grants.go
+++ b/internal/management/grants.go
@@ -1,0 +1,564 @@
+package management
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/authz"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+	"github.com/i-got-this-faa/fbs/internal/storage"
+)
+
+type grantResponse struct {
+	ID            string `json:"id"`
+	Bucket        string `json:"bucket"`
+	GranteeUserID string `json:"grantee_user_id"`
+	Action        string `json:"action"`
+	KeyPrefix     string `json:"key_prefix"`
+	IsActive      bool   `json:"is_active"`
+	CreatedBy     string `json:"created_by,omitempty"`
+	Note          string `json:"note,omitempty"`
+	CreatedAt     string `json:"created_at"`
+	UpdatedAt     string `json:"updated_at"`
+}
+
+type grantsResponse struct {
+	Grants []grantResponse `json:"grants"`
+}
+
+type grantEnvelopeResponse struct {
+	Grant grantResponse `json:"grant"`
+}
+
+type createGrantsResponse struct {
+	Grants []grantResponse `json:"grants"`
+}
+
+type transferOwnershipRequest struct {
+	NewOwnerUserID string `json:"new_owner_user_id"`
+}
+
+type transferOwnershipResponse struct {
+	Bucket  bucketSummaryResponse `json:"bucket"`
+	OwnerID string                `json:"owner_id"`
+}
+
+func grantDTO(g metadata.Grant) grantResponse {
+	return grantResponse{
+		ID:            g.ID,
+		Bucket:        g.BucketName,
+		GranteeUserID: g.GranteeUserID,
+		Action:        g.Action,
+		KeyPrefix:     g.KeyPrefix,
+		IsActive:      g.IsActive,
+		CreatedBy:     g.CreatedBy,
+		Note:          g.Note,
+		CreatedAt:     formatTime(g.CreatedAt),
+		UpdatedAt:     formatTime(g.UpdatedAt),
+	}
+}
+
+// ListBucketGrants lists grants for a bucket. Admin or bucket owner.
+func (h *Handlers) ListBucketGrants(w http.ResponseWriter, r *http.Request) {
+	bucket, ok := h.loadBucketForGrantAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	grants, err := h.Grants.ListByBucket(r.Context(), bucket.Name)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list grants")
+		return
+	}
+
+	items := make([]grantResponse, 0, len(grants))
+	for _, g := range grants {
+		items = append(items, grantDTO(g))
+	}
+	writeJSON(w, http.StatusOK, grantsResponse{Grants: items})
+}
+
+// CreateBucketGrants creates one grant row per action. Admin or bucket owner.
+func (h *Handlers) CreateBucketGrants(w http.ResponseWriter, r *http.Request) {
+	bucket, ok := h.loadBucketForGrantAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	input, ok := decodeCreateGrantRequest(w, r)
+	if !ok {
+		return
+	}
+
+	grantee, ok := h.resolveGrantee(w, r, input.granteeUserID, input.granteeAccessKeyID)
+	if !ok {
+		return
+	}
+	if !grantee.IsActive {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "grantee user is inactive")
+		return
+	}
+
+	if err := validateGrantPrefix(input.keyPrefix); err != nil {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, err.Error())
+		return
+	}
+
+	principal, _ := auth.PrincipalFromContext(r.Context())
+	now := time.Now().UTC()
+	created := make([]grantResponse, 0, len(input.actions))
+
+	for _, action := range input.actions {
+		grant := &metadata.Grant{
+			ID:            uuid.NewString(),
+			BucketName:    bucket.Name,
+			GranteeUserID: grantee.ID,
+			Action:        action,
+			KeyPrefix:     input.keyPrefix,
+			IsActive:      true,
+			CreatedBy:     principal.UserID,
+			Note:          input.note,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+		result, existed, err := h.Grants.CreateIdempotent(r.Context(), grant)
+		if err != nil {
+			if errors.Is(err, metadata.ErrInvalidGrantAction) {
+				writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid or non-grantable action")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to create grant")
+			return
+		}
+		created = append(created, grantDTO(*result))
+		if !existed {
+			h.recordActivity(r, "create_grant", bucket.Name, action, 0, result.ID)
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, createGrantsResponse{Grants: created})
+}
+
+// PatchBucketGrant updates prefix, active, or note. Admin or bucket owner.
+func (h *Handlers) PatchBucketGrant(w http.ResponseWriter, r *http.Request) {
+	bucket, ok := h.loadBucketForGrantAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	grantID := strings.TrimSpace(chi.URLParam(r, "grantID"))
+	grant, ok := h.loadGrantOnBucket(w, r, grantID, bucket.Name)
+	if !ok {
+		return
+	}
+
+	input, ok := decodePatchGrantRequest(w, r)
+	if !ok {
+		return
+	}
+
+	if input.keyPrefix != nil {
+		if err := validateGrantPrefix(*input.keyPrefix); err != nil {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, err.Error())
+			return
+		}
+		grant.KeyPrefix = *input.keyPrefix
+	}
+	if input.isActive != nil {
+		grant.IsActive = *input.isActive
+	}
+	if input.note != nil {
+		grant.Note = *input.note
+	}
+
+	if err := h.Grants.Update(r.Context(), grant); err != nil {
+		if errors.Is(err, metadata.ErrGrantNotFound) {
+			writeError(w, http.StatusNotFound, errorCodeNotFound, "grant not found")
+			return
+		}
+		if errors.Is(err, metadata.ErrInvalidGrantAction) {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid or non-grantable action")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to update grant")
+		return
+	}
+
+	updated, err := h.Grants.GetByID(r.Context(), grant.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load updated grant")
+		return
+	}
+	h.recordActivity(r, "update_grant", bucket.Name, updated.Action, 0, updated.ID)
+	writeJSON(w, http.StatusOK, grantEnvelopeResponse{Grant: grantDTO(*updated)})
+}
+
+// DeleteBucketGrant deletes a grant. Admin or bucket owner.
+func (h *Handlers) DeleteBucketGrant(w http.ResponseWriter, r *http.Request) {
+	bucket, ok := h.loadBucketForGrantAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	grantID := strings.TrimSpace(chi.URLParam(r, "grantID"))
+	grant, ok := h.loadGrantOnBucket(w, r, grantID, bucket.Name)
+	if !ok {
+		return
+	}
+
+	if err := h.Grants.Delete(r.Context(), grant.ID); err != nil {
+		if errors.Is(err, metadata.ErrGrantNotFound) {
+			writeError(w, http.StatusNotFound, errorCodeNotFound, "grant not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to delete grant")
+		return
+	}
+	h.recordActivity(r, "delete_grant", bucket.Name, grant.Action, 0, grant.ID)
+	setNoStoreHeaders(w)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListMyGrants lists grants for the authenticated principal.
+func (h *Handlers) ListMyGrants(w http.ResponseWriter, r *http.Request) {
+	principal, ok := auth.PrincipalFromContext(r.Context())
+	if !ok || strings.TrimSpace(principal.UserID) == "" {
+		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "authentication required")
+		return
+	}
+
+	grants, err := h.Grants.ListByGrantee(r.Context(), principal.UserID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list grants")
+		return
+	}
+
+	items := make([]grantResponse, 0, len(grants))
+	for _, g := range grants {
+		items = append(items, grantDTO(g))
+	}
+	writeJSON(w, http.StatusOK, grantsResponse{Grants: items})
+}
+
+// ListUserGrants lists grants for a user. Admin only.
+func (h *Handlers) ListUserGrants(w http.ResponseWriter, r *http.Request) {
+	userID := strings.TrimSpace(chi.URLParam(r, "userID"))
+	if userID == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "user not found")
+		return
+	}
+
+	if _, err := h.Users.GetByID(r.Context(), userID); errors.Is(err, metadata.ErrUserNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "user not found")
+		return
+	} else if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load user")
+		return
+	}
+
+	grants, err := h.Grants.ListByGrantee(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to list grants")
+		return
+	}
+
+	items := make([]grantResponse, 0, len(grants))
+	for _, g := range grants {
+		items = append(items, grantDTO(g))
+	}
+	writeJSON(w, http.StatusOK, grantsResponse{Grants: items})
+}
+
+// TransferBucketOwnership transfers bucket ownership. Admin or current owner.
+func (h *Handlers) TransferBucketOwnership(w http.ResponseWriter, r *http.Request) {
+	bucket, ok := h.loadBucketForGrantAdmin(w, r)
+	if !ok {
+		return
+	}
+
+	var req transferOwnershipRequest
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+		return
+	}
+	newOwnerID := strings.TrimSpace(req.NewOwnerUserID)
+	if newOwnerID == "" {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "new_owner_user_id is required")
+		return
+	}
+
+	newOwner, err := h.Users.GetByID(r.Context(), newOwnerID)
+	if errors.Is(err, metadata.ErrUserNotFound) {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "new owner user not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load new owner")
+		return
+	}
+	if !newOwner.IsActive {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "new owner user is inactive")
+		return
+	}
+
+	if err := h.Buckets.UpdateOwner(r.Context(), bucket.Name, newOwner.ID); err != nil {
+		if errors.Is(err, metadata.ErrBucketNotFound) {
+			writeError(w, http.StatusNotFound, errorCodeNotFound, "bucket not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to transfer ownership")
+		return
+	}
+
+	h.recordActivity(r, "transfer_bucket_ownership", bucket.Name, newOwner.ID, 0, "")
+
+	summary, err := h.Management.GetBucketSummary(r.Context(), bucket.Name)
+	if err != nil {
+		// Ownership already transferred; return the known owner id.
+		writeJSON(w, http.StatusOK, transferOwnershipResponse{
+			Bucket: bucketSummaryResponse{
+				Name:      bucket.Name,
+				OwnerID:   newOwner.ID,
+				CreatedAt: formatTime(bucket.CreatedAt),
+			},
+			OwnerID: newOwner.ID,
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, transferOwnershipResponse{
+		Bucket:  bucketSummaryDTO(summary),
+		OwnerID: newOwner.ID,
+	})
+}
+
+func (h *Handlers) loadBucketForGrantAdmin(w http.ResponseWriter, r *http.Request) (*metadata.Bucket, bool) {
+	bucketName := strings.TrimSpace(chi.URLParam(r, "bucket"))
+	if bucketName == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "bucket not found")
+		return nil, false
+	}
+
+	bucket, err := h.Buckets.GetByName(r.Context(), bucketName)
+	if errors.Is(err, metadata.ErrBucketNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "bucket not found")
+		return nil, false
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load bucket")
+		return nil, false
+	}
+
+	principal, ok := auth.PrincipalFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, errorCodeUnauthorized, "authentication required")
+		return nil, false
+	}
+	if principal.Role != "admin" && bucket.OwnerID != principal.UserID {
+		writeError(w, http.StatusForbidden, errorCodeForbidden, "admin or bucket owner required")
+		return nil, false
+	}
+	return bucket, true
+}
+
+func (h *Handlers) loadGrantOnBucket(w http.ResponseWriter, r *http.Request, grantID, bucketName string) (*metadata.Grant, bool) {
+	if grantID == "" {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "grant not found")
+		return nil, false
+	}
+	grant, err := h.Grants.GetByID(r.Context(), grantID)
+	if errors.Is(err, metadata.ErrGrantNotFound) {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "grant not found")
+		return nil, false
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load grant")
+		return nil, false
+	}
+	if grant.BucketName != bucketName {
+		writeError(w, http.StatusNotFound, errorCodeNotFound, "grant not found")
+		return nil, false
+	}
+	return grant, true
+}
+
+func (h *Handlers) resolveGrantee(w http.ResponseWriter, r *http.Request, userID, accessKeyID string) (*metadata.User, bool) {
+	userID = strings.TrimSpace(userID)
+	accessKeyID = strings.TrimSpace(accessKeyID)
+
+	switch {
+	case userID != "" && accessKeyID != "":
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "provide grantee_user_id or grantee_access_key_id, not both")
+		return nil, false
+	case userID != "":
+		user, err := h.Users.GetByID(r.Context(), userID)
+		if errors.Is(err, metadata.ErrUserNotFound) {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "grantee user not found")
+			return nil, false
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load grantee")
+			return nil, false
+		}
+		return user, true
+	case accessKeyID != "":
+		user, err := h.Users.GetByAccessKeyID(r.Context(), accessKeyID)
+		if errors.Is(err, metadata.ErrUserNotFound) {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "grantee access key not found")
+			return nil, false
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, errorCodeInternal, "failed to load grantee")
+			return nil, false
+		}
+		return user, true
+	default:
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "grantee_user_id or grantee_access_key_id is required")
+		return nil, false
+	}
+}
+
+type createGrantInput struct {
+	granteeUserID      string
+	granteeAccessKeyID string
+	actions            []string
+	keyPrefix          string
+	note               string
+}
+
+func decodeCreateGrantRequest(w http.ResponseWriter, r *http.Request) (createGrantInput, bool) {
+	var raw struct {
+		GranteeUserID      string   `json:"grantee_user_id"`
+		GranteeAccessKeyID string   `json:"grantee_access_key_id"`
+		Actions            []string `json:"actions"`
+		Action             string   `json:"action"`
+		KeyPrefix          string   `json:"key_prefix"`
+		Note               string   `json:"note"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&raw); err != nil {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+		return createGrantInput{}, false
+	}
+
+	actions := make([]string, 0, len(raw.Actions)+1)
+	seen := make(map[string]struct{})
+	for _, action := range raw.Actions {
+		action = strings.TrimSpace(action)
+		if action == "" {
+			continue
+		}
+		if !authz.IsGrantable(action) {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid or non-grantable action: "+action)
+			return createGrantInput{}, false
+		}
+		if _, ok := seen[action]; ok {
+			continue
+		}
+		seen[action] = struct{}{}
+		actions = append(actions, action)
+	}
+	if single := strings.TrimSpace(raw.Action); single != "" {
+		if !authz.IsGrantable(single) {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid or non-grantable action: "+single)
+			return createGrantInput{}, false
+		}
+		if _, ok := seen[single]; !ok {
+			actions = append(actions, single)
+		}
+	}
+	if len(actions) == 0 {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "at least one action is required")
+		return createGrantInput{}, false
+	}
+
+	return createGrantInput{
+		granteeUserID:      strings.TrimSpace(raw.GranteeUserID),
+		granteeAccessKeyID: strings.TrimSpace(raw.GranteeAccessKeyID),
+		actions:            actions,
+		keyPrefix:          raw.KeyPrefix,
+		note:               strings.TrimSpace(raw.Note),
+	}, true
+}
+
+type patchGrantInput struct {
+	keyPrefix *string
+	isActive  *bool
+	note      *string
+}
+
+func decodePatchGrantRequest(w http.ResponseWriter, r *http.Request) (patchGrantInput, bool) {
+	var rawFields map[string]json.RawMessage
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&rawFields); err != nil {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+		return patchGrantInput{}, false
+	}
+
+	for field := range rawFields {
+		if field != "key_prefix" && field != "is_active" && field != "note" {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "invalid JSON request body")
+			return patchGrantInput{}, false
+		}
+	}
+	if len(rawFields) == 0 {
+		writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "at least one field is required")
+		return patchGrantInput{}, false
+	}
+
+	var input patchGrantInput
+	if raw, exists := rawFields["key_prefix"]; exists {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil || string(raw) == "null" {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "key_prefix must be a string")
+			return patchGrantInput{}, false
+		}
+		input.keyPrefix = &value
+	}
+	if _, exists := rawFields["is_active"]; exists {
+		isActive, ok := decodeBoolField(w, rawFields, "is_active")
+		if !ok {
+			return patchGrantInput{}, false
+		}
+		input.isActive = &isActive
+	}
+	if raw, exists := rawFields["note"]; exists {
+		var value string
+		if err := json.Unmarshal(raw, &value); err != nil || string(raw) == "null" {
+			writeError(w, http.StatusBadRequest, errorCodeInvalidRequest, "note must be a string")
+			return patchGrantInput{}, false
+		}
+		value = strings.TrimSpace(value)
+		input.note = &value
+	}
+	return input, true
+}
+
+func validateGrantPrefix(prefix string) error {
+	if prefix == "" {
+		return nil
+	}
+	if strings.Contains(prefix, "\x00") || strings.Contains(prefix, "\n") || strings.Contains(prefix, "\r") {
+		return errors.New("invalid key_prefix")
+	}
+	if strings.HasPrefix(prefix, "/") {
+		return errors.New("invalid key_prefix")
+	}
+	// Folder-style prefixes end with "/"; validate the non-empty stem as a key.
+	toCheck := strings.TrimSuffix(prefix, "/")
+	if toCheck == "" {
+		return errors.New("invalid key_prefix")
+	}
+	if err := storage.ValidateKey(toCheck); err != nil {
+		return errors.New("invalid key_prefix")
+	}
+	return nil
+}

--- a/internal/management/grants_test.go
+++ b/internal/management/grants_test.go
@@ -1,0 +1,195 @@
+package management_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+func TestManagementAdminCreateAndListGrants(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+
+	body := strings.NewReader(`{
+		"grantee_user_id":"` + env.memberUserID + `",
+		"actions":["s3:GetObject","s3:ListBucket"],
+		"key_prefix":"2026/",
+		"note":"read photos"
+	}`)
+	resp := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.adminToken, body)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	var created struct {
+		Grants []struct {
+			ID            string `json:"id"`
+			Action        string `json:"action"`
+			GranteeUserID string `json:"grantee_user_id"`
+			KeyPrefix     string `json:"key_prefix"`
+		} `json:"grants"`
+	}
+	decodeResponse(t, resp, &created)
+	if len(created.Grants) != 2 {
+		t.Fatalf("grants = %+v, want 2", created.Grants)
+	}
+
+	list := env.do(t, http.MethodGet, "/api/management/buckets/photos/grants", env.adminToken, nil)
+	defer list.Body.Close()
+	if list.StatusCode != http.StatusOK {
+		t.Fatalf("list status = %d", list.StatusCode)
+	}
+	var listed struct {
+		Grants []json.RawMessage `json:"grants"`
+	}
+	decodeResponse(t, list, &listed)
+	if len(listed.Grants) != 2 {
+		t.Fatalf("listed len = %d", len(listed.Grants))
+	}
+
+	// Idempotent create returns existing.
+	again := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.adminToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.memberUserID+`",
+		"actions":["s3:GetObject"],
+		"key_prefix":"2026/"
+	}`))
+	defer again.Body.Close()
+	if again.StatusCode != http.StatusCreated {
+		t.Fatalf("idempotent status = %d body=%s", again.StatusCode, readBody(t, again))
+	}
+}
+
+func TestManagementMemberCannotMutateForeignGrants(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	resp := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.memberToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.memberUserID+`",
+		"actions":["s3:GetObject"]
+	}`))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+}
+
+func TestManagementMemberListMyGrants(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	create := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.adminToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.memberUserID+`",
+		"actions":["s3:GetObject"]
+	}`))
+	defer create.Body.Close()
+	if create.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d body=%s", create.StatusCode, readBody(t, create))
+	}
+
+	resp := env.do(t, http.MethodGet, "/api/management/grants/me", env.memberToken, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var body struct {
+		Grants []struct {
+			Bucket string `json:"bucket"`
+			Action string `json:"action"`
+		} `json:"grants"`
+	}
+	decodeResponse(t, resp, &body)
+	if len(body.Grants) != 1 || body.Grants[0].Bucket != "photos" {
+		t.Fatalf("my grants = %+v", body.Grants)
+	}
+}
+
+func TestManagementRejectNonGrantableAction(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	resp := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.adminToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.memberUserID+`",
+		"actions":["s3:DeleteBucket"]
+	}`))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", resp.StatusCode, readBody(t, resp))
+	}
+}
+
+func TestManagementOwnerCanGrantOnOwnBucket(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	// Create a bucket owned by the member.
+	if err := metadata.NewBucketRepository(env.db).Create(context.Background(), &metadata.Bucket{
+		Name:      "member-owned",
+		OwnerID:   env.memberUserID,
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	resp := env.do(t, http.MethodPost, "/api/management/buckets/member-owned/grants", env.memberToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.adminUserID+`",
+		"actions":["s3:ListBucket"]
+	}`))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+}
+
+func TestManagementTransferOwnership(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	resp := env.do(t, http.MethodPost, "/api/management/buckets/photos/transfer-ownership", env.adminToken, strings.NewReader(`{
+		"new_owner_user_id":"`+env.memberUserID+`"
+	}`))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, readBody(t, resp))
+	}
+
+	bucket, err := metadata.NewBucketRepository(env.db).GetByName(context.Background(), "photos")
+	if err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if bucket.OwnerID != env.memberUserID {
+		t.Fatalf("owner = %s, want %s", bucket.OwnerID, env.memberUserID)
+	}
+}
+
+func TestManagementDeleteGrant(t *testing.T) {
+	t.Parallel()
+
+	env := newManagementTestEnv(t)
+	create := env.do(t, http.MethodPost, "/api/management/buckets/photos/grants", env.adminToken, strings.NewReader(`{
+		"grantee_user_id":"`+env.memberUserID+`",
+		"actions":["s3:GetObject"]
+	}`))
+	defer create.Body.Close()
+	var created struct {
+		Grants []struct {
+			ID string `json:"id"`
+		} `json:"grants"`
+	}
+	decodeResponse(t, create, &created)
+	if len(created.Grants) != 1 {
+		t.Fatalf("created = %+v", created)
+	}
+
+	del := env.do(t, http.MethodDelete, "/api/management/buckets/photos/grants/"+created.Grants[0].ID, env.adminToken, nil)
+	defer del.Body.Close()
+	if del.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d body=%s", del.StatusCode, readBody(t, del))
+	}
+}

--- a/internal/management/handlers.go
+++ b/internal/management/handlers.go
@@ -35,6 +35,7 @@ type Handlers struct {
 	Objects          metadata.ObjectRepository
 	Activity         metadata.ActivityRepository
 	Users            metadata.UserRepository
+	Grants           metadata.GrantRepository
 	Storage          storage.DiskEngine
 	Config           config.Config
 	PublicReadSigner *publicread.Signer

--- a/internal/management/handlers_test.go
+++ b/internal/management/handlers_test.go
@@ -807,12 +807,14 @@ func newManagementTestEnvWithConfig(t *testing.T, cfg config.Config) managementT
 			t.Fatalf("new public read signer: %v", err)
 		}
 	}
+	grantRepo := metadata.NewGrantRepository(db)
 	handlers := &management.Handlers{
 		Management:       metadata.NewManagementRepository(db),
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
 		Activity:         metadata.NewActivityRepository(db),
 		Users:            userRepo,
+		Grants:           grantRepo,
 		Storage:          disk,
 		Config:           cfg,
 		PublicReadSigner: signer,
@@ -830,6 +832,8 @@ func newManagementTestEnvWithConfig(t *testing.T, cfg config.Config) managementT
 		Users:            userRepo,
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
+		Grants:           grantRepo,
+		Authz:            s3.NewAuthzEvaluator(grantRepo),
 		Storage:          disk,
 		Logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
 		S3CacheControl:   cfg.S3CacheControl,
@@ -839,8 +843,11 @@ func newManagementTestEnvWithConfig(t *testing.T, cfg config.Config) managementT
 		s3.RegisterPublicReadRoutes(r, objectHandlers)
 		r.Route("/api/management", func(managementRoutes chi.Router) {
 			managementRoutes.Use(auth.RequireAuthentication(authChain, management.WriteAuthError))
-			managementRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
-			management.RegisterRoutes(managementRoutes, handlers)
+			management.RegisterGrantRoutes(managementRoutes, handlers)
+			managementRoutes.Group(func(adminRoutes chi.Router) {
+				adminRoutes.Use(auth.RequireRole("admin", management.WriteAuthError))
+				management.RegisterAdminRoutes(adminRoutes, handlers)
+			})
 		})
 	})
 

--- a/internal/management/routes.go
+++ b/internal/management/routes.go
@@ -2,7 +2,8 @@ package management
 
 import "github.com/go-chi/chi/v5"
 
-func RegisterRoutes(r chi.Router, h *Handlers) {
+// RegisterAdminRoutes registers admin-only management routes.
+func RegisterAdminRoutes(r chi.Router, h *Handlers) {
 	r.Get("/metrics", h.Metrics)
 	r.Get("/config", h.ConfigInfo)
 	r.Get("/activity", h.ListActivity)
@@ -17,4 +18,24 @@ func RegisterRoutes(r chi.Router, h *Handlers) {
 	r.Post("/keys", h.CreateKey)
 	r.Patch("/keys/{id}", h.PatchKey)
 	r.Delete("/keys/{id}", h.DeleteKey)
+	r.Get("/users/{userID}/grants", h.ListUserGrants)
+}
+
+// RegisterGrantRoutes registers grant and ownership routes that allow
+// authenticated admins or bucket owners (and self-list for my grants).
+// Call after authentication middleware, without requiring admin role.
+func RegisterGrantRoutes(r chi.Router, h *Handlers) {
+	r.Get("/grants/me", h.ListMyGrants)
+	r.Get("/buckets/{bucket}/grants", h.ListBucketGrants)
+	r.Post("/buckets/{bucket}/grants", h.CreateBucketGrants)
+	r.Patch("/buckets/{bucket}/grants/{grantID}", h.PatchBucketGrant)
+	r.Delete("/buckets/{bucket}/grants/{grantID}", h.DeleteBucketGrant)
+	r.Post("/buckets/{bucket}/transfer-ownership", h.TransferBucketOwnership)
+}
+
+// RegisterRoutes registers all management routes under a single router.
+// Prefer RegisterAdminRoutes + RegisterGrantRoutes when role middleware differs.
+func RegisterRoutes(r chi.Router, h *Handlers) {
+	RegisterGrantRoutes(r, h)
+	RegisterAdminRoutes(r, h)
 }

--- a/internal/metadata/bucket.go
+++ b/internal/metadata/bucket.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,8 @@ type BucketRepository interface {
 	GetByName(ctx context.Context, name string) (*Bucket, error)
 	List(ctx context.Context) ([]Bucket, error)
 	ListByOwner(ctx context.Context, ownerID string) ([]Bucket, error)
+	ListByNames(ctx context.Context, names []string) ([]Bucket, error)
+	UpdateOwner(ctx context.Context, name, ownerID string) error
 	Delete(ctx context.Context, name string) error
 }
 
@@ -119,6 +122,62 @@ func (r *sqliteBucketRepository) ListByOwner(ctx context.Context, ownerID string
 	}
 
 	return buckets, nil
+}
+
+func (r *sqliteBucketRepository) ListByNames(ctx context.Context, names []string) ([]Bucket, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(names))
+	args := make([]any, len(names))
+	for i, name := range names {
+		placeholders[i] = "?"
+		args[i] = name
+	}
+
+	q := fmt.Sprintf(`
+		SELECT name, owner_id, created_at
+		FROM buckets
+		WHERE name IN (%s)
+		ORDER BY created_at ASC`, strings.Join(placeholders, ", "))
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list buckets by names: %w", err)
+	}
+	defer rows.Close()
+
+	var buckets []Bucket
+	for rows.Next() {
+		b, err := scanBucketRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list buckets by names scan: %w", err)
+		}
+		buckets = append(buckets, *b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list buckets by names rows: %w", err)
+	}
+	return buckets, nil
+}
+
+func (r *sqliteBucketRepository) UpdateOwner(ctx context.Context, name, ownerID string) error {
+	const q = `UPDATE buckets SET owner_id = ? WHERE name = ?`
+
+	result, err := r.db.ExecContext(ctx, q, ownerID, name)
+	if err != nil {
+		return fmt.Errorf("update bucket owner: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update bucket owner rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrBucketNotFound
+	}
+	return nil
 }
 
 func (r *sqliteBucketRepository) Delete(ctx context.Context, name string) error {

--- a/internal/metadata/cache.go
+++ b/internal/metadata/cache.go
@@ -259,6 +259,18 @@ func (r *cachedBucketRepository) ListByOwner(ctx context.Context, ownerID string
 	return r.delegate.ListByOwner(ctx, ownerID)
 }
 
+func (r *cachedBucketRepository) ListByNames(ctx context.Context, names []string) ([]Bucket, error) {
+	return r.delegate.ListByNames(ctx, names)
+}
+
+func (r *cachedBucketRepository) UpdateOwner(ctx context.Context, name, ownerID string) error {
+	if err := r.delegate.UpdateOwner(ctx, name, ownerID); err != nil {
+		return err
+	}
+	r.cache.evictBucket(name)
+	return nil
+}
+
 func (r *cachedBucketRepository) Delete(ctx context.Context, name string) error {
 	if err := r.delegate.Delete(ctx, name); err != nil {
 		return err

--- a/internal/metadata/grant.go
+++ b/internal/metadata/grant.go
@@ -1,0 +1,398 @@
+package metadata
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// grantableActions is the set of actions that may be stored on grant rows.
+// Kept local to avoid an import cycle with internal/authz (auth → metadata → authz → auth).
+var grantableActions = map[string]struct{}{
+	"s3:ListBucket":               {},
+	"s3:GetObject":                {},
+	"s3:PutObject":                {},
+	"s3:DeleteObject":             {},
+	"s3:ListMultipartUploadParts": {},
+	"s3:AbortMultipartUpload":     {},
+}
+
+func isGrantableAction(action string) bool {
+	_, ok := grantableActions[action]
+	return ok
+}
+
+// Grant represents a row in the grants table.
+type Grant struct {
+	ID            string
+	BucketName    string
+	GranteeUserID string
+	Action        string
+	KeyPrefix     string
+	IsActive      bool
+	CreatedBy     string
+	Note          string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// ErrGrantNotFound is returned when a grant lookup yields no rows.
+var ErrGrantNotFound = errors.New("grant not found")
+
+// ErrInvalidGrantAction is returned when a non-grantable action is written.
+var ErrInvalidGrantAction = errors.New("invalid grant action")
+
+// GrantRepository persists and queries resource grants.
+type GrantRepository interface {
+	Create(ctx context.Context, grant *Grant) error
+	// CreateIdempotent inserts a grant or returns the existing active grant
+	// with the same (bucket, grantee, action, prefix).
+	CreateIdempotent(ctx context.Context, grant *Grant) (*Grant, bool, error)
+	GetByID(ctx context.Context, id string) (*Grant, error)
+	Update(ctx context.Context, grant *Grant) error
+	Delete(ctx context.Context, id string) error
+	ListByBucket(ctx context.Context, bucketName string) ([]Grant, error)
+	ListByGrantee(ctx context.Context, granteeUserID string) ([]Grant, error)
+	ListActiveForGranteeBucket(ctx context.Context, granteeUserID, bucketName string) ([]Grant, error)
+	ListBucketNamesWithActiveGrants(ctx context.Context, granteeUserID string) ([]string, error)
+}
+
+type sqliteGrantRepository struct {
+	db *sql.DB
+}
+
+// NewGrantRepository returns a GrantRepository backed by the given *sql.DB.
+func NewGrantRepository(db *sql.DB) GrantRepository {
+	return &sqliteGrantRepository{db: db}
+}
+
+func (r *sqliteGrantRepository) Create(ctx context.Context, grant *Grant) error {
+	if err := validateGrantWrite(grant); err != nil {
+		return err
+	}
+
+	const q = `
+		INSERT INTO grants (
+			id, bucket_name, grantee_user_id, action, key_prefix,
+			is_active, created_by, note, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	createdBy := sql.NullString{String: grant.CreatedBy, Valid: grant.CreatedBy != ""}
+	note := sql.NullString{String: grant.Note, Valid: grant.Note != ""}
+
+	_, err := r.db.ExecContext(ctx, q,
+		grant.ID,
+		grant.BucketName,
+		grant.GranteeUserID,
+		grant.Action,
+		grant.KeyPrefix,
+		boolToInt(grant.IsActive),
+		createdBy,
+		note,
+		grant.CreatedAt.UTC(),
+		grant.UpdatedAt.UTC(),
+	)
+	if err != nil {
+		return fmt.Errorf("create grant: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteGrantRepository) CreateIdempotent(ctx context.Context, grant *Grant) (*Grant, bool, error) {
+	if err := validateGrantWrite(grant); err != nil {
+		return nil, false, err
+	}
+
+	existing, err := r.findActiveDuplicate(ctx, grant.BucketName, grant.GranteeUserID, grant.Action, grant.KeyPrefix)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing != nil {
+		return existing, true, nil
+	}
+
+	if err := r.Create(ctx, grant); err != nil {
+		// Race: another writer may have inserted the same active grant.
+		if isUniqueConstraintError(err) {
+			existing, lookupErr := r.findActiveDuplicate(ctx, grant.BucketName, grant.GranteeUserID, grant.Action, grant.KeyPrefix)
+			if lookupErr != nil {
+				return nil, false, lookupErr
+			}
+			if existing != nil {
+				return existing, true, nil
+			}
+		}
+		return nil, false, err
+	}
+	return grant, false, nil
+}
+
+func (r *sqliteGrantRepository) findActiveDuplicate(ctx context.Context, bucketName, granteeUserID, action, keyPrefix string) (*Grant, error) {
+	const q = `
+		SELECT id, bucket_name, grantee_user_id, action, key_prefix,
+		       is_active, created_by, note, created_at, updated_at
+		FROM grants
+		WHERE bucket_name = ?
+		  AND grantee_user_id = ?
+		  AND action = ?
+		  AND key_prefix = ?
+		  AND is_active = 1
+		LIMIT 1`
+
+	row := r.db.QueryRowContext(ctx, q, bucketName, granteeUserID, action, keyPrefix)
+	grant, err := scanGrant(row)
+	if errors.Is(err, ErrGrantNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return grant, nil
+}
+
+func (r *sqliteGrantRepository) GetByID(ctx context.Context, id string) (*Grant, error) {
+	const q = `
+		SELECT id, bucket_name, grantee_user_id, action, key_prefix,
+		       is_active, created_by, note, created_at, updated_at
+		FROM grants
+		WHERE id = ?`
+
+	row := r.db.QueryRowContext(ctx, q, id)
+	return scanGrant(row)
+}
+
+func (r *sqliteGrantRepository) Update(ctx context.Context, grant *Grant) error {
+	if grant == nil || strings.TrimSpace(grant.ID) == "" {
+		return ErrGrantNotFound
+	}
+	if grant.IsActive && !isGrantableAction(grant.Action) {
+		return ErrInvalidGrantAction
+	}
+
+	const q = `
+		UPDATE grants
+		SET key_prefix = ?,
+		    is_active = ?,
+		    note = ?,
+		    updated_at = ?
+		WHERE id = ?`
+
+	note := sql.NullString{String: grant.Note, Valid: grant.Note != ""}
+	result, err := r.db.ExecContext(ctx, q,
+		grant.KeyPrefix,
+		boolToInt(grant.IsActive),
+		note,
+		time.Now().UTC(),
+		grant.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update grant: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update grant rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrGrantNotFound
+	}
+	return nil
+}
+
+func (r *sqliteGrantRepository) Delete(ctx context.Context, id string) error {
+	const q = `DELETE FROM grants WHERE id = ?`
+
+	result, err := r.db.ExecContext(ctx, q, id)
+	if err != nil {
+		return fmt.Errorf("delete grant: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete grant rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrGrantNotFound
+	}
+	return nil
+}
+
+func (r *sqliteGrantRepository) ListByBucket(ctx context.Context, bucketName string) ([]Grant, error) {
+	const q = `
+		SELECT id, bucket_name, grantee_user_id, action, key_prefix,
+		       is_active, created_by, note, created_at, updated_at
+		FROM grants
+		WHERE bucket_name = ?
+		ORDER BY created_at ASC, id ASC`
+
+	return r.list(ctx, q, bucketName)
+}
+
+func (r *sqliteGrantRepository) ListByGrantee(ctx context.Context, granteeUserID string) ([]Grant, error) {
+	const q = `
+		SELECT id, bucket_name, grantee_user_id, action, key_prefix,
+		       is_active, created_by, note, created_at, updated_at
+		FROM grants
+		WHERE grantee_user_id = ?
+		ORDER BY created_at ASC, id ASC`
+
+	return r.list(ctx, q, granteeUserID)
+}
+
+func (r *sqliteGrantRepository) ListActiveForGranteeBucket(ctx context.Context, granteeUserID, bucketName string) ([]Grant, error) {
+	const q = `
+		SELECT id, bucket_name, grantee_user_id, action, key_prefix,
+		       is_active, created_by, note, created_at, updated_at
+		FROM grants
+		WHERE grantee_user_id = ?
+		  AND bucket_name = ?
+		  AND is_active = 1`
+
+	return r.list(ctx, q, granteeUserID, bucketName)
+}
+
+func (r *sqliteGrantRepository) ListBucketNamesWithActiveGrants(ctx context.Context, granteeUserID string) ([]string, error) {
+	const q = `
+		SELECT DISTINCT bucket_name
+		FROM grants
+		WHERE grantee_user_id = ?
+		  AND is_active = 1
+		ORDER BY bucket_name ASC`
+
+	rows, err := r.db.QueryContext(ctx, q, granteeUserID)
+	if err != nil {
+		return nil, fmt.Errorf("list grant bucket names: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scan grant bucket name: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list grant bucket names rows: %w", err)
+	}
+	return names, nil
+}
+
+func (r *sqliteGrantRepository) list(ctx context.Context, query string, args ...any) ([]Grant, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list grants: %w", err)
+	}
+	defer rows.Close()
+
+	var grants []Grant
+	for rows.Next() {
+		g, err := scanGrantRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		grants = append(grants, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list grants rows: %w", err)
+	}
+	return grants, nil
+}
+
+func validateGrantWrite(grant *Grant) error {
+	if grant == nil {
+		return fmt.Errorf("grant is nil")
+	}
+	if !isGrantableAction(grant.Action) {
+		return ErrInvalidGrantAction
+	}
+	return nil
+}
+
+func scanGrant(row *sql.Row) (*Grant, error) {
+	var g Grant
+	var isActive int
+	var createdBy, note sql.NullString
+	var createdAt, updatedAt string
+
+	err := row.Scan(
+		&g.ID,
+		&g.BucketName,
+		&g.GranteeUserID,
+		&g.Action,
+		&g.KeyPrefix,
+		&isActive,
+		&createdBy,
+		&note,
+		&createdAt,
+		&updatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrGrantNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan grant: %w", err)
+	}
+
+	g.IsActive = isActive != 0
+	g.CreatedBy = createdBy.String
+	g.Note = note.String
+
+	var parseErr error
+	g.CreatedAt, parseErr = parseTimestamp(createdAt)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	g.UpdatedAt, parseErr = parseTimestamp(updatedAt)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return &g, nil
+}
+
+func scanGrantRow(rows *sql.Rows) (*Grant, error) {
+	var g Grant
+	var isActive int
+	var createdBy, note sql.NullString
+	var createdAt, updatedAt string
+
+	err := rows.Scan(
+		&g.ID,
+		&g.BucketName,
+		&g.GranteeUserID,
+		&g.Action,
+		&g.KeyPrefix,
+		&isActive,
+		&createdBy,
+		&note,
+		&createdAt,
+		&updatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("scan grant row: %w", err)
+	}
+
+	g.IsActive = isActive != 0
+	g.CreatedBy = createdBy.String
+	g.Note = note.String
+
+	g.CreatedAt, err = parseTimestamp(createdAt)
+	if err != nil {
+		return nil, err
+	}
+	g.UpdatedAt, err = parseTimestamp(updatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") || strings.Contains(msg, "constraint failed")
+}

--- a/internal/metadata/grant.go
+++ b/internal/metadata/grant.go
@@ -7,10 +7,14 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
 )
 
 // grantableActions is the set of actions that may be stored on grant rows.
 // Kept local to avoid an import cycle with internal/authz (auth → metadata → authz → auth).
+// Keep in sync with authz.GrantableActions; TestGrantableActionsInSync enforces this.
 var grantableActions = map[string]struct{}{
 	"s3:ListBucket":               {},
 	"s3:GetObject":                {},
@@ -18,6 +22,15 @@ var grantableActions = map[string]struct{}{
 	"s3:DeleteObject":             {},
 	"s3:ListMultipartUploadParts": {},
 	"s3:AbortMultipartUpload":     {},
+}
+
+// GrantableActions returns the actions accepted on grant rows.
+func GrantableActions() []string {
+	out := make([]string, 0, len(grantableActions))
+	for action := range grantableActions {
+		out = append(out, action)
+	}
+	return out
 }
 
 func isGrantableAction(action string) bool {
@@ -44,6 +57,10 @@ var ErrGrantNotFound = errors.New("grant not found")
 
 // ErrInvalidGrantAction is returned when a non-grantable action is written.
 var ErrInvalidGrantAction = errors.New("invalid grant action")
+
+// ErrDuplicateGrant is returned when an update would create a second active
+// grant for the same (bucket, grantee, action, prefix).
+var ErrDuplicateGrant = errors.New("duplicate active grant")
 
 // GrantRepository persists and queries resource grants.
 type GrantRepository interface {
@@ -189,6 +206,9 @@ func (r *sqliteGrantRepository) Update(ctx context.Context, grant *Grant) error 
 		grant.ID,
 	)
 	if err != nil {
+		if isUniqueConstraintError(err) {
+			return ErrDuplicateGrant
+		}
 		return fmt.Errorf("update grant: %w", err)
 	}
 	rows, err := result.RowsAffected()
@@ -393,6 +413,18 @@ func isUniqueConstraintError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "unique constraint") || strings.Contains(msg, "constraint failed")
+	var se *sqlite.Error
+	if errors.As(err, &se) {
+		code := se.Code()
+		if code == sqlite3.SQLITE_CONSTRAINT_UNIQUE {
+			return true
+		}
+		// Some paths only set the primary SQLITE_CONSTRAINT code.
+		if code&0xff == sqlite3.SQLITE_CONSTRAINT &&
+			strings.Contains(strings.ToLower(se.Error()), "unique") {
+			return true
+		}
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "unique constraint")
 }

--- a/internal/metadata/grant_test.go
+++ b/internal/metadata/grant_test.go
@@ -1,0 +1,209 @@
+package metadata
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func uniqueTestUser(displayName string) *User {
+	u := newTestUser()
+	u.DisplayName = displayName
+	u.AccessKeyID = "ak_" + uuid.NewString()
+	u.SigV4AccessKeyID = "fbsv4_" + uuid.NewString()
+	return u
+}
+
+func TestGrantCreateAndList(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(t.TempDir() + "/grants.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	users := NewUserRepository(db)
+	owner := uniqueTestUser("Owner")
+	grantee := uniqueTestUser("Grantee")
+	if err := users.Create(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := users.Create(ctx, grantee); err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+
+	buckets := NewBucketRepository(db)
+	if err := buckets.Create(ctx, &Bucket{Name: "photos", OwnerID: owner.ID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	grants := NewGrantRepository(db)
+	now := time.Now().UTC().Truncate(time.Second)
+	g := &Grant{
+		ID:            uuid.NewString(),
+		BucketName:    "photos",
+		GranteeUserID: grantee.ID,
+		Action:        "s3:GetObject",
+		KeyPrefix:     "2026/",
+		IsActive:      true,
+		CreatedBy:     owner.ID,
+		Note:          "read 2026",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if err := grants.Create(ctx, g); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	listed, err := grants.ListByBucket(ctx, "photos")
+	if err != nil {
+		t.Fatalf("list by bucket: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Action != "s3:GetObject" {
+		t.Fatalf("listed = %+v", listed)
+	}
+
+	active, err := grants.ListActiveForGranteeBucket(ctx, grantee.ID, "photos")
+	if err != nil {
+		t.Fatalf("list active: %v", err)
+	}
+	if len(active) != 1 || active[0].KeyPrefix != "2026/" {
+		t.Fatalf("active = %+v", active)
+	}
+
+	names, err := grants.ListBucketNamesWithActiveGrants(ctx, grantee.ID)
+	if err != nil {
+		t.Fatalf("bucket names: %v", err)
+	}
+	if len(names) != 1 || names[0] != "photos" {
+		t.Fatalf("names = %v", names)
+	}
+}
+
+func TestGrantCreateIdempotent(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(t.TempDir() + "/grants-idem.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	users := NewUserRepository(db)
+	owner := uniqueTestUser("Owner")
+	grantee := uniqueTestUser("Grantee")
+	if err := users.Create(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := users.Create(ctx, grantee); err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	if err := NewBucketRepository(db).Create(ctx, &Bucket{Name: "b", OwnerID: owner.ID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	grants := NewGrantRepository(db)
+	now := time.Now().UTC()
+	first := &Grant{
+		ID: uuid.NewString(), BucketName: "b", GranteeUserID: grantee.ID,
+		Action: "s3:ListBucket", IsActive: true, CreatedBy: owner.ID,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	got, existed, err := grants.CreateIdempotent(ctx, first)
+	if err != nil || existed {
+		t.Fatalf("first: got=%+v existed=%v err=%v", got, existed, err)
+	}
+
+	second := &Grant{
+		ID: uuid.NewString(), BucketName: "b", GranteeUserID: grantee.ID,
+		Action: "s3:ListBucket", IsActive: true, CreatedBy: owner.ID,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	got, existed, err = grants.CreateIdempotent(ctx, second)
+	if err != nil || !existed {
+		t.Fatalf("second: got=%+v existed=%v err=%v", got, existed, err)
+	}
+	if got.ID != first.ID {
+		t.Fatalf("id = %s, want %s", got.ID, first.ID)
+	}
+}
+
+func TestGrantRejectsNonGrantableAction(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(t.TempDir() + "/grants-bad.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	users := NewUserRepository(db)
+	owner := uniqueTestUser("Owner")
+	grantee := uniqueTestUser("Grantee")
+	if err := users.Create(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := users.Create(ctx, grantee); err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	if err := NewBucketRepository(db).Create(ctx, &Bucket{Name: "b", OwnerID: owner.ID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	err = NewGrantRepository(db).Create(ctx, &Grant{
+		ID: uuid.NewString(), BucketName: "b", GranteeUserID: grantee.ID,
+		Action: "s3:DeleteBucket", IsActive: true, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+	if !errors.Is(err, ErrInvalidGrantAction) {
+		t.Fatalf("err = %v, want ErrInvalidGrantAction", err)
+	}
+}
+
+func TestGrantCascadeOnBucketDelete(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(t.TempDir() + "/grants-cascade.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	users := NewUserRepository(db)
+	owner := uniqueTestUser("Owner")
+	grantee := uniqueTestUser("Grantee")
+	if err := users.Create(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := users.Create(ctx, grantee); err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	buckets := NewBucketRepository(db)
+	if err := buckets.Create(ctx, &Bucket{Name: "gone", OwnerID: owner.ID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	grants := NewGrantRepository(db)
+	id := uuid.NewString()
+	if err := grants.Create(ctx, &Grant{
+		ID: id, BucketName: "gone", GranteeUserID: grantee.ID,
+		Action: "s3:GetObject", IsActive: true,
+		CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	if err := buckets.Delete(ctx, "gone"); err != nil {
+		t.Fatalf("delete bucket: %v", err)
+	}
+	if _, err := grants.GetByID(ctx, id); !errors.Is(err, ErrGrantNotFound) {
+		t.Fatalf("grant after cascade: %v", err)
+	}
+}

--- a/internal/metadata/grant_test.go
+++ b/internal/metadata/grant_test.go
@@ -166,6 +166,54 @@ func TestGrantRejectsNonGrantableAction(t *testing.T) {
 	}
 }
 
+func TestGrantUpdateDuplicateActiveConflict(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(t.TempDir() + "/grants-dup.db")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	users := NewUserRepository(db)
+	owner := uniqueTestUser("Owner")
+	grantee := uniqueTestUser("Grantee")
+	if err := users.Create(ctx, owner); err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := users.Create(ctx, grantee); err != nil {
+		t.Fatalf("create grantee: %v", err)
+	}
+	if err := NewBucketRepository(db).Create(ctx, &Bucket{Name: "b", OwnerID: owner.ID, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	grants := NewGrantRepository(db)
+	now := time.Now().UTC()
+	inactive := &Grant{
+		ID: uuid.NewString(), BucketName: "b", GranteeUserID: grantee.ID,
+		Action: "s3:GetObject", KeyPrefix: "docs/", IsActive: false,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := grants.Create(ctx, inactive); err != nil {
+		t.Fatalf("create inactive: %v", err)
+	}
+	active := &Grant{
+		ID: uuid.NewString(), BucketName: "b", GranteeUserID: grantee.ID,
+		Action: "s3:GetObject", KeyPrefix: "docs/", IsActive: true,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := grants.Create(ctx, active); err != nil {
+		t.Fatalf("create active: %v", err)
+	}
+
+	inactive.IsActive = true
+	if err := grants.Update(ctx, inactive); !errors.Is(err, ErrDuplicateGrant) {
+		t.Fatalf("update err = %v, want ErrDuplicateGrant", err)
+	}
+}
+
 func TestGrantCascadeOnBucketDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/s3/access.go
+++ b/internal/s3/access.go
@@ -6,10 +6,77 @@ import (
 	"strings"
 
 	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 )
 
-func (h *ObjectHandlers) loadBucketForAccess(w http.ResponseWriter, r *http.Request, bucketName string) (*metadata.Bucket, bool) {
+// authorize checks whether the request principal may perform action on the
+// given bucket/key. On deny it writes AccessDenied; on evaluator failure it
+// writes InternalError. Returns true only when access is allowed.
+func (h *ObjectHandlers) authorize(w http.ResponseWriter, r *http.Request, action, bucketName, objectKey, listPrefix string, bucket *metadata.Bucket) bool {
+	principal, ok := auth.PrincipalFromContext(r.Context())
+	if !ok || strings.TrimSpace(principal.UserID) == "" {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+
+	ownerID := ""
+	if bucket != nil {
+		ownerID = bucket.OwnerID
+	}
+
+	allowed, err := h.evaluator().Allow(r.Context(), authz.DecisionRequest{
+		Principal:     principal,
+		Action:        action,
+		Bucket:        bucketName,
+		ObjectKey:     objectKey,
+		ListPrefix:    listPrefix,
+		BucketOwnerID: ownerID,
+	})
+	if err != nil {
+		h.logError("authorize", err, bucketName, objectKey, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return false
+	}
+	if !allowed {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+	return true
+}
+
+// authorizeQuiet is like authorize but does not write an HTTP response.
+// Used for multi-object delete per-key checks.
+func (h *ObjectHandlers) authorizeQuiet(r *http.Request, action, bucketName, objectKey string, bucket *metadata.Bucket) (bool, error) {
+	principal, ok := auth.PrincipalFromContext(r.Context())
+	if !ok || strings.TrimSpace(principal.UserID) == "" {
+		return false, nil
+	}
+
+	ownerID := ""
+	if bucket != nil {
+		ownerID = bucket.OwnerID
+	}
+
+	return h.evaluator().Allow(r.Context(), authz.DecisionRequest{
+		Principal:     principal,
+		Action:        action,
+		Bucket:        bucketName,
+		ObjectKey:     objectKey,
+		BucketOwnerID: ownerID,
+	})
+}
+
+func (h *ObjectHandlers) evaluator() *authz.Evaluator {
+	if h.Authz != nil {
+		return h.Authz
+	}
+	// Fail closed when no evaluator is wired.
+	return &authz.Evaluator{}
+}
+
+// loadBucket loads bucket metadata without authorization.
+func (h *ObjectHandlers) loadBucket(w http.ResponseWriter, r *http.Request, bucketName string) (*metadata.Bucket, bool) {
 	if strings.TrimSpace(bucketName) == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
 		return nil, false
@@ -25,26 +92,34 @@ func (h *ObjectHandlers) loadBucketForAccess(w http.ResponseWriter, r *http.Requ
 		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
 		return nil, false
 	}
-
-	principal, ok := auth.PrincipalFromContext(r.Context())
-	if !ok || !principalCanAccessBucket(principal, bucket) {
-		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
-		return nil, false
-	}
-
 	return bucket, true
 }
 
-func principalCanAccessBucket(principal auth.Principal, bucket *metadata.Bucket) bool {
-	if bucket == nil || strings.TrimSpace(principal.UserID) == "" {
-		return false
+// loadBucketForAction loads the bucket and authorizes action-specific access.
+func (h *ObjectHandlers) loadBucketForAction(w http.ResponseWriter, r *http.Request, bucketName, action, objectKey, listPrefix string) (*metadata.Bucket, bool) {
+	bucket, ok := h.loadBucket(w, r, bucketName)
+	if !ok {
+		return nil, false
 	}
-	return principal.Role == "admin" || bucket.OwnerID == principal.UserID
+	if !h.authorize(w, r, action, bucketName, objectKey, listPrefix, bucket) {
+		return nil, false
+	}
+	return bucket, true
 }
 
-func (h *ObjectHandlers) ensureBucket(w http.ResponseWriter, r *http.Request, bucketName string) bool {
-	_, ok := h.loadBucketForAccess(w, r, bucketName)
+// ensureBucketAction authorizes the given action on an existing bucket.
+// objectKey and listPrefix are optional depending on the action.
+func (h *ObjectHandlers) ensureBucketAction(w http.ResponseWriter, r *http.Request, bucketName, action, objectKey, listPrefix string) bool {
+	_, ok := h.loadBucketForAction(w, r, bucketName, action, objectKey, listPrefix)
 	return ok
+}
+
+// ensureBucket is retained for call sites that only need existence + coarse
+// access. Prefer ensureBucketAction with an explicit action when possible.
+// It uses s3:ListBucket with an empty list prefix so owners/admins and
+// whole-bucket list grantees pass; object operations should use their action.
+func (h *ObjectHandlers) ensureBucket(w http.ResponseWriter, r *http.Request, bucketName string) bool {
+	return h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", "")
 }
 
 func requireSignedHeader(w http.ResponseWriter, r *http.Request, headerName string) bool {

--- a/internal/s3/access.go
+++ b/internal/s3/access.go
@@ -114,14 +114,6 @@ func (h *ObjectHandlers) ensureBucketAction(w http.ResponseWriter, r *http.Reque
 	return ok
 }
 
-// ensureBucket is retained for call sites that only need existence + coarse
-// access. Prefer ensureBucketAction with an explicit action when possible.
-// It uses s3:ListBucket with an empty list prefix so owners/admins and
-// whole-bucket list grantees pass; object operations should use their action.
-func (h *ObjectHandlers) ensureBucket(w http.ResponseWriter, r *http.Request, bucketName string) bool {
-	return h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", "")
-}
-
 func requireSignedHeader(w http.ResponseWriter, r *http.Request, headerName string) bool {
 	if requestHasSignedHeader(r, headerName) {
 		return true

--- a/internal/s3/access.go
+++ b/internal/s3/access.go
@@ -67,6 +67,42 @@ func (h *ObjectHandlers) authorizeQuiet(r *http.Request, action, bucketName, obj
 	})
 }
 
+// authorizeBucketRelationship allows the request only when the principal is an
+// admin, the bucket owner, or holds at least one active grant on the bucket.
+// Callers with no relationship to the bucket get AccessDenied (same top-level
+// deny shape as other handlers), rather than a success-shaped multi-status body.
+func (h *ObjectHandlers) authorizeBucketRelationship(w http.ResponseWriter, r *http.Request, bucket *metadata.Bucket) bool {
+	if bucket == nil {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+
+	principal, ok := auth.PrincipalFromContext(r.Context())
+	if !ok || strings.TrimSpace(principal.UserID) == "" {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+	if principal.Role == "admin" || bucket.OwnerID == principal.UserID {
+		return true
+	}
+	if h.Grants == nil {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+
+	grants, err := h.Grants.ListActiveForGranteeBucket(r.Context(), principal.UserID, bucket.Name)
+	if err != nil {
+		h.logError("list grants for bucket relationship", err, bucket.Name, "", "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return false
+	}
+	if len(grants) == 0 {
+		WriteS3Error(w, r, http.StatusForbidden, codeAccessDenied, messageAccessDenied)
+		return false
+	}
+	return true
+}
+
 func (h *ObjectHandlers) evaluator() *authz.Evaluator {
 	if h.Authz != nil {
 		return h.Authz

--- a/internal/s3/authz_store.go
+++ b/internal/s3/authz_store.go
@@ -1,0 +1,34 @@
+package s3
+
+import (
+	"context"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+// NewAuthzEvaluator builds an evaluator backed by the grant repository.
+func NewAuthzEvaluator(grants metadata.GrantRepository) *authz.Evaluator {
+	if grants == nil {
+		return &authz.Evaluator{}
+	}
+	return &authz.Evaluator{
+		Grants: authz.FuncStore(func(ctx context.Context, granteeUserID, bucketName string) ([]authz.Grant, error) {
+			rows, err := grants.ListActiveForGranteeBucket(ctx, granteeUserID, bucketName)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]authz.Grant, 0, len(rows))
+			for _, row := range rows {
+				out = append(out, authz.Grant{
+					BucketName:    row.BucketName,
+					GranteeUserID: row.GranteeUserID,
+					Action:        row.Action,
+					KeyPrefix:     row.KeyPrefix,
+					Active:        row.IsActive,
+				})
+			}
+			return out, nil
+		}),
+	}
+}

--- a/internal/s3/bucket_delete.go
+++ b/internal/s3/bucket_delete.go
@@ -5,12 +5,13 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 )
 
 func (h *ObjectHandlers) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 	bucketName := chiBucketParam(r)
-	if !h.ensureBucket(w, r, bucketName) {
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionDeleteBucket, "", "") {
 		return
 	}
 

--- a/internal/s3/bucket_handlers.go
+++ b/internal/s3/bucket_handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 )
 
@@ -80,13 +81,12 @@ func (h *ObjectHandlers) ListObjectsV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bucketName := chiBucketParam(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
-
 	params, err := parseListObjectsV2Params(r)
 	if err != nil {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", params.prefix) {
 		return
 	}
 

--- a/internal/s3/bucket_handlers_test.go
+++ b/internal/s3/bucket_handlers_test.go
@@ -969,10 +969,13 @@ func newScopedS3TestEnv(t *testing.T, principal auth.Principal) objectTestEnv {
 		t.Fatalf("new storage: %v", err)
 	}
 	objectRepo := metadata.NewObjectRepository(db)
+	grantRepo := metadata.NewGrantRepository(db)
 	handlers := &ObjectHandlers{
 		Users:   userRepo,
 		Buckets: bucketRepo,
 		Objects: objectRepo,
+		Grants:  grantRepo,
+		Authz:   NewAuthzEvaluator(grantRepo),
 		Storage: disk,
 		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
@@ -992,6 +995,7 @@ func newScopedS3TestEnv(t *testing.T, principal auth.Principal) objectTestEnv {
 		users:   userRepo,
 		buckets: bucketRepo,
 		objects: objectRepo,
+		grants:  grantRepo,
 		storage: disk,
 		bucket:  "member-bucket",
 		dataDir: t.TempDir(),
@@ -1029,10 +1033,13 @@ func newSigV4S3TestEnv(t *testing.T) objectTestEnv {
 		t.Fatalf("new storage: %v", err)
 	}
 	objectRepo := metadata.NewObjectRepository(db)
+	grantRepo := metadata.NewGrantRepository(db)
 	handlers := &ObjectHandlers{
 		Users:   userRepo,
 		Buckets: bucketRepo,
 		Objects: objectRepo,
+		Grants:  grantRepo,
+		Authz:   NewAuthzEvaluator(grantRepo),
 		Storage: disk,
 	}
 	authChain := &auth.ChainAuthenticator{

--- a/internal/s3/bucket_handlers_test.go
+++ b/internal/s3/bucket_handlers_test.go
@@ -1062,6 +1062,7 @@ func newSigV4S3TestEnv(t *testing.T) objectTestEnv {
 		users:   userRepo,
 		buckets: bucketRepo,
 		objects: objectRepo,
+		grants:  grantRepo,
 		storage: disk,
 		sigv4:   sigv4,
 		bucket:  bucketName,

--- a/internal/s3/bucket_head.go
+++ b/internal/s3/bucket_head.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"net/http"
 
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/s3compat"
 )
 
@@ -14,7 +15,7 @@ func (h *ObjectHandlers) HeadBucket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("x-amz-bucket-region", s3compat.Region)
-	if !h.ensureBucket(w, r, bucketName) {
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", "") {
 		return
 	}
 

--- a/internal/s3/bucket_location.go
+++ b/internal/s3/bucket_location.go
@@ -3,6 +3,8 @@ package s3
 import (
 	"encoding/xml"
 	"net/http"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
 )
 
 type locationConstraintResult struct {
@@ -13,7 +15,7 @@ type locationConstraintResult struct {
 
 func (h *ObjectHandlers) GetBucketLocation(w http.ResponseWriter, r *http.Request) {
 	bucketName := chiBucketParam(r)
-	if !h.ensureBucket(w, r, bucketName) {
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", "") {
 		return
 	}
 

--- a/internal/s3/copy_object.go
+++ b/internal/s3/copy_object.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 )
 
@@ -24,9 +25,6 @@ type copySource struct {
 
 func (h *ObjectHandlers) CopyObject(w http.ResponseWriter, r *http.Request) {
 	destinationBucket, destinationKey := objectRouteParams(r)
-	if !h.ensureBucket(w, r, destinationBucket) {
-		return
-	}
 	if destinationKey == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
 		return
@@ -48,7 +46,11 @@ func (h *ObjectHandlers) CopyObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.ensureBucket(w, r, source.bucketName) {
+	// Copy requires get on source and put on destination (both checks always).
+	if !h.ensureBucketAction(w, r, source.bucketName, authz.ActionGetObject, source.key, "") {
+		return
+	}
+	if !h.ensureBucketAction(w, r, destinationBucket, authz.ActionPutObject, destinationKey, "") {
 		return
 	}
 

--- a/internal/s3/delete_objects.go
+++ b/internal/s3/delete_objects.go
@@ -90,13 +90,13 @@ func (h *ObjectHandlers) DeleteObjects(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !allowed {
-			if !req.Quiet {
-				result.Errors = append(result.Errors, deleteObjectError{
-					Key:     key,
-					Code:    codeAccessDenied,
-					Message: messageAccessDenied,
-				})
-			}
+			// Quiet mode suppresses <Deleted> entries only; per-key <Error>
+			// entries must still be returned (AWS S3 multi-delete contract).
+			result.Errors = append(result.Errors, deleteObjectError{
+				Key:     key,
+				Code:    codeAccessDenied,
+				Message: messageAccessDenied,
+			})
 			continue
 		}
 

--- a/internal/s3/delete_objects.go
+++ b/internal/s3/delete_objects.go
@@ -51,6 +51,12 @@ func (h *ObjectHandlers) DeleteObjects(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	// Deny callers with no relationship to the bucket before per-key auth.
+	// Without this, strangers get 200 + AccessDenied errors and can tell the
+	// bucket exists more cheaply than via other ops' 403 shape consistency.
+	if !h.authorizeBucketRelationship(w, r, bucket) {
+		return
+	}
 
 	req, err := parseDeleteObjectsRequest(r)
 	if err != nil {

--- a/internal/s3/delete_objects.go
+++ b/internal/s3/delete_objects.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
 )
 
 const maxDeleteObjects = 1000
@@ -30,15 +32,23 @@ type deleteObjectsResult struct {
 	XMLName xml.Name             `xml:"DeleteResult"`
 	Xmlns   string               `xml:"xmlns,attr"`
 	Deleted []deletedObjectEntry `xml:"Deleted,omitempty"`
+	Errors  []deleteObjectError  `xml:"Error,omitempty"`
 }
 
 type deletedObjectEntry struct {
 	Key string `xml:"Key"`
 }
 
+type deleteObjectError struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
 func (h *ObjectHandlers) DeleteObjects(w http.ResponseWriter, r *http.Request) {
 	bucketName := chiBucketParam(r)
-	if !h.ensureBucket(w, r, bucketName) {
+	bucket, ok := h.loadBucket(w, r, bucketName)
+	if !ok {
 		return
 	}
 
@@ -69,9 +79,27 @@ func (h *ObjectHandlers) DeleteObjects(w http.ResponseWriter, r *http.Request) {
 	result := deleteObjectsResult{
 		Xmlns:   "http://s3.amazonaws.com/doc/2006-03-01/",
 		Deleted: make([]deletedObjectEntry, 0, len(req.Objects)),
+		Errors:  make([]deleteObjectError, 0),
 	}
 	for _, requestedObject := range req.Objects {
 		key := requestedObject.Key
+		allowed, authErr := h.authorizeQuiet(r, authz.ActionDeleteObject, bucketName, key, bucket)
+		if authErr != nil {
+			h.logError("authorize delete object in batch", authErr, bucketName, key, "")
+			WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+			return
+		}
+		if !allowed {
+			if !req.Quiet {
+				result.Errors = append(result.Errors, deleteObjectError{
+					Key:     key,
+					Code:    codeAccessDenied,
+					Message: messageAccessDenied,
+				})
+			}
+			continue
+		}
+
 		obj, existed, err := h.deleteObject(r, bucketName, key)
 		if err != nil {
 			h.logError("delete object in batch", err, bucketName, key, "")

--- a/internal/s3/grantable_actions_sync_test.go
+++ b/internal/s3/grantable_actions_sync_test.go
@@ -1,0 +1,31 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+// TestGrantableActionsInSync keeps metadata's grantable-action set aligned with
+// authz.GrantableActions. The two packages cannot share a single source without
+// an import cycle (auth → metadata → authz → auth).
+func TestGrantableActionsInSync(t *testing.T) {
+	t.Parallel()
+
+	fromMetadata := map[string]struct{}{}
+	for _, action := range metadata.GrantableActions() {
+		fromMetadata[action] = struct{}{}
+	}
+
+	for action := range authz.GrantableActions {
+		if _, ok := fromMetadata[action]; !ok {
+			t.Errorf("action %q is in authz.GrantableActions but missing from metadata.GrantableActions", action)
+		}
+	}
+	for action := range fromMetadata {
+		if _, ok := authz.GrantableActions[action]; !ok {
+			t.Errorf("action %q is in metadata.GrantableActions but missing from authz.GrantableActions", action)
+		}
+	}
+}

--- a/internal/s3/grants_access_test.go
+++ b/internal/s3/grants_access_test.go
@@ -1,0 +1,134 @@
+package s3
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/i-got-this-faa/fbs/internal/auth"
+	"github.com/i-got-this-faa/fbs/internal/authz"
+	"github.com/i-got-this-faa/fbs/internal/metadata"
+)
+
+func TestGranteeCanGetObjectWithGrant(t *testing.T) {
+	t.Parallel()
+
+	env := newScopedS3TestEnv(t, auth.Principal{
+		UserID:      "member-user",
+		DisplayName: "Member User",
+		AccessKeyID: "member",
+		Role:        "member",
+	})
+
+	now := time.Now().UTC()
+	storagePath, size, err := env.storage.Write(context.Background(), "other-bucket", "shared2.txt", strings.NewReader("data"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := env.objects.Create(context.Background(), &metadata.Object{
+		ID: uuid.NewString(), BucketName: "other-bucket", Key: "shared2.txt",
+		Size: size, ETag: "e", ContentType: "text/plain", StoragePath: storagePath,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("create object metadata: %v", err)
+	}
+
+	if env.grants == nil {
+		t.Fatal("grants repo missing")
+	}
+	_, _, err = env.grants.CreateIdempotent(context.Background(), &metadata.Grant{
+		ID: uuid.NewString(), BucketName: "other-bucket", GranteeUserID: "member-user",
+		Action: authz.ActionGetObject, IsActive: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	put := env.do(t, http.MethodPut, "/other-bucket/nope.txt", "x", nil)
+	if put.Code != http.StatusForbidden {
+		t.Fatalf("put status = %d, want 403", put.Code)
+	}
+
+	get := env.do(t, http.MethodGet, "/other-bucket/shared2.txt", "", nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want 200; body=%s", get.Code, get.Body.String())
+	}
+	if get.Body.String() != "data" {
+		t.Fatalf("body = %q", get.Body.String())
+	}
+}
+
+func TestListBucketsIncludesGrantedBuckets(t *testing.T) {
+	t.Parallel()
+
+	env := newScopedS3TestEnv(t, auth.Principal{
+		UserID:      "member-user",
+		DisplayName: "Member User",
+		AccessKeyID: "member",
+		Role:        "member",
+	})
+
+	now := time.Now().UTC()
+	_, _, err := env.grants.CreateIdempotent(context.Background(), &metadata.Grant{
+		ID: uuid.NewString(), BucketName: "other-bucket", GranteeUserID: "member-user",
+		Action: authz.ActionGetObject, IsActive: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	list := env.do(t, http.MethodGet, "/", "", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list status = %d; body=%s", list.Code, list.Body.String())
+	}
+	var result listAllMyBucketsResult
+	if err := xml.Unmarshal(list.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	names := map[string]bool{}
+	for _, b := range result.Buckets.Buckets {
+		names[b.Name] = true
+	}
+	if !names["member-bucket"] || !names["other-bucket"] {
+		t.Fatalf("buckets = %v, want member-bucket and other-bucket", names)
+	}
+}
+
+func TestPrefixLimitedPutDeniedOutsidePrefix(t *testing.T) {
+	t.Parallel()
+
+	env := newScopedS3TestEnv(t, auth.Principal{
+		UserID:      "member-user",
+		DisplayName: "Member User",
+		AccessKeyID: "member",
+		Role:        "member",
+	})
+
+	now := time.Now().UTC()
+	for _, action := range []string{authz.ActionPutObject, authz.ActionListBucket} {
+		_, _, err := env.grants.CreateIdempotent(context.Background(), &metadata.Grant{
+			ID: uuid.NewString(), BucketName: "other-bucket", GranteeUserID: "member-user",
+			Action: action, KeyPrefix: "uploads/", IsActive: true,
+			CreatedAt: now, UpdatedAt: now,
+		})
+		if err != nil {
+			t.Fatalf("create grant %s: %v", action, err)
+		}
+	}
+
+	allowed := env.do(t, http.MethodPut, "/other-bucket/uploads/a.txt", "ok", nil)
+	if allowed.Code != http.StatusOK {
+		t.Fatalf("allowed put status = %d; body=%s", allowed.Code, allowed.Body.String())
+	}
+
+	denied := env.do(t, http.MethodPut, "/other-bucket/secret.txt", "no", nil)
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("denied put status = %d, want 403", denied.Code)
+	}
+}

--- a/internal/s3/grants_access_test.go
+++ b/internal/s3/grants_access_test.go
@@ -102,6 +102,82 @@ func TestListBucketsIncludesGrantedBuckets(t *testing.T) {
 	}
 }
 
+func TestDeleteObjectsDeniesStrangerWithoutGrants(t *testing.T) {
+	t.Parallel()
+
+	env := newScopedS3TestEnv(t, auth.Principal{
+		UserID:      "member-user",
+		DisplayName: "Member User",
+		AccessKeyID: "member",
+		Role:        "member",
+	})
+
+	// Member has no grants on other-bucket; multi-delete must be top-level 403,
+	// not 200 with per-key errors.
+	body := `<Delete><Object><Key>any.txt</Key></Object></Delete>`
+	resp := env.do(t, http.MethodPost, "/other-bucket?delete", body, deleteObjectsHeaders(body))
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", resp.Code, resp.Body.String())
+	}
+	assertS3ErrorCode(t, resp.Body.Bytes(), codeAccessDenied)
+}
+
+func TestDeleteObjectsPartialGrantReportsPerKeyErrors(t *testing.T) {
+	t.Parallel()
+
+	env := newScopedS3TestEnv(t, auth.Principal{
+		UserID:      "member-user",
+		DisplayName: "Member User",
+		AccessKeyID: "member",
+		Role:        "member",
+	})
+
+	now := time.Now().UTC()
+	// Relationship to the bucket via a delete grant limited to uploads/.
+	_, _, err := env.grants.CreateIdempotent(context.Background(), &metadata.Grant{
+		ID: uuid.NewString(), BucketName: "other-bucket", GranteeUserID: "member-user",
+		Action: authz.ActionDeleteObject, KeyPrefix: "uploads/", IsActive: true,
+		CreatedAt: now, UpdatedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	// Seed two keys under other-bucket.
+	for _, key := range []string{"uploads/ok.txt", "secret.txt"} {
+		path, size, err := env.storage.Write(context.Background(), "other-bucket", key, strings.NewReader("x"))
+		if err != nil {
+			t.Fatalf("write %s: %v", key, err)
+		}
+		if err := env.objects.Create(context.Background(), &metadata.Object{
+			ID: uuid.NewString(), BucketName: "other-bucket", Key: key,
+			Size: size, ETag: "e", ContentType: "text/plain", StoragePath: path,
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatalf("create object %s: %v", key, err)
+		}
+	}
+
+	body := `<Delete>
+		<Object><Key>uploads/ok.txt</Key></Object>
+		<Object><Key>secret.txt</Key></Object>
+	</Delete>`
+	resp := env.do(t, http.MethodPost, "/other-bucket?delete", body, deleteObjectsHeaders(body))
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.Code, resp.Body.String())
+	}
+	var result deleteObjectsResult
+	if err := xml.Unmarshal(resp.Body.Bytes(), &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result.Deleted) != 1 || result.Deleted[0].Key != "uploads/ok.txt" {
+		t.Fatalf("deleted = %+v, want uploads/ok.txt", result.Deleted)
+	}
+	if len(result.Errors) != 1 || result.Errors[0].Key != "secret.txt" || result.Errors[0].Code != codeAccessDenied {
+		t.Fatalf("errors = %+v, want secret.txt AccessDenied", result.Errors)
+	}
+}
+
 func TestPrefixLimitedPutDeniedOutsidePrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/s3/grants_access_test.go
+++ b/internal/s3/grants_access_test.go
@@ -74,6 +74,8 @@ func TestListBucketsIncludesGrantedBuckets(t *testing.T) {
 	})
 
 	now := time.Now().UTC()
+	// ListBuckets visibility requires any active grant (not specifically
+	// s3:ListBucket). GetObject is enough to surface the bucket in the listing.
 	_, _, err := env.grants.CreateIdempotent(context.Background(), &metadata.Grant{
 		ID: uuid.NewString(), BucketName: "other-bucket", GranteeUserID: "member-user",
 		Action: authz.ActionGetObject, IsActive: true,

--- a/internal/s3/list_buckets.go
+++ b/internal/s3/list_buckets.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"encoding/xml"
 	"net/http"
+	"sort"
 
 	"github.com/i-got-this-faa/fbs/internal/auth"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
@@ -36,15 +37,7 @@ func (h *ObjectHandlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var (
-		buckets []metadata.Bucket
-		err     error
-	)
-	if principal.Role == "admin" {
-		buckets, err = h.Buckets.List(r.Context())
-	} else {
-		buckets, err = h.Buckets.ListByOwner(r.Context(), principal.UserID)
-	}
+	buckets, err := h.listBucketsForPrincipal(r, principal)
 	if err != nil {
 		h.logError("list buckets", err, "", "", "")
 		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
@@ -69,4 +62,58 @@ func (h *ObjectHandlers) ListBuckets(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/xml")
 	w.WriteHeader(http.StatusOK)
 	_ = xml.NewEncoder(w).Encode(result)
+}
+
+func (h *ObjectHandlers) listBucketsForPrincipal(r *http.Request, principal auth.Principal) ([]metadata.Bucket, error) {
+	if principal.Role == "admin" {
+		return h.Buckets.List(r.Context())
+	}
+
+	owned, err := h.Buckets.ListByOwner(r.Context(), principal.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if h.Grants == nil {
+		return owned, nil
+	}
+
+	grantedNames, err := h.Grants.ListBucketNamesWithActiveGrants(r.Context(), principal.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if len(grantedNames) == 0 {
+		return owned, nil
+	}
+
+	granted, err := h.Buckets.ListByNames(r.Context(), grantedNames)
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeBucketsByName(owned, granted), nil
+}
+
+func mergeBucketsByName(owned, granted []metadata.Bucket) []metadata.Bucket {
+	byName := make(map[string]metadata.Bucket, len(owned)+len(granted))
+	for _, b := range owned {
+		byName[b.Name] = b
+	}
+	for _, b := range granted {
+		if _, exists := byName[b.Name]; !exists {
+			byName[b.Name] = b
+		}
+	}
+
+	merged := make([]metadata.Bucket, 0, len(byName))
+	for _, b := range byName {
+		merged = append(merged, b)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].CreatedAt.Equal(merged[j].CreatedAt) {
+			return merged[i].Name < merged[j].Name
+		}
+		return merged[i].CreatedAt.Before(merged[j].CreatedAt)
+	})
+	return merged
 }

--- a/internal/s3/list_objects_v1.go
+++ b/internal/s3/list_objects_v1.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
 )
 
 type listBucketV1Result struct {
@@ -33,13 +35,12 @@ type listObjectsV1Params struct {
 
 func (h *ObjectHandlers) ListObjectsV1(w http.ResponseWriter, r *http.Request) {
 	bucketName := chiBucketParam(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
-
 	params, err := parseListObjectsV1Params(r)
 	if err != nil {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", params.prefix) {
 		return
 	}
 

--- a/internal/s3/multipart_handlers.go
+++ b/internal/s3/multipart_handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 	"github.com/i-got-this-faa/fbs/internal/storage"
 )
@@ -20,11 +21,11 @@ const cleanupTimeout = 30 * time.Second
 // CreateMultipartUpload handles POST /{bucket}/{key}?uploads.
 func (h *ObjectHandlers) CreateMultipartUpload(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
 		return
 	}
 	if err := storage.ValidateKey(key); err != nil {
@@ -63,11 +64,11 @@ func (h *ObjectHandlers) CreateMultipartUpload(w http.ResponseWriter, r *http.Re
 // UploadPart handles PUT /{bucket}/{key}?partNumber={n}&uploadId={id}.
 func (h *ObjectHandlers) UploadPart(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
 		return
 	}
 
@@ -184,11 +185,11 @@ func (h *ObjectHandlers) UploadPart(w http.ResponseWriter, r *http.Request) {
 // CompleteMultipartUpload handles POST /{bucket}/{key}?uploadId={id}.
 func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
 		return
 	}
 
@@ -406,11 +407,11 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 // AbortMultipartUpload handles DELETE /{bucket}/{key}?uploadId={id}.
 func (h *ObjectHandlers) AbortMultipartUpload(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionAbortMultipartUpload, key, "") {
 		return
 	}
 

--- a/internal/s3/multipart_handlers_test.go
+++ b/internal/s3/multipart_handlers_test.go
@@ -548,11 +548,14 @@ func TestCompleteMultipartUploadEnforcesMinPartSize(t *testing.T) {
 
 	objectRepo := metadata.NewObjectRepository(db)
 	multipartRepo := metadata.NewMultipartUploadRepository(db)
+	grantRepo := metadata.NewGrantRepository(db)
 	handlers := &ObjectHandlers{
 		Users:            userRepo,
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
 		MultipartUploads: multipartRepo,
+		Grants:           grantRepo,
+		Authz:            NewAuthzEvaluator(grantRepo),
 		Storage:          disk,
 		Now:              func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) },
 		NewID:            newSequentialID(),

--- a/internal/s3/object_handlers.go
+++ b/internal/s3/object_handlers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 	"github.com/i-got-this-faa/fbs/internal/publicread"
 	"github.com/i-got-this-faa/fbs/internal/storage"
@@ -21,6 +22,8 @@ type ObjectHandlers struct {
 	Objects          metadata.ObjectRepository
 	Activity         metadata.ActivityRepository
 	MultipartUploads metadata.MultipartUploadRepository
+	Grants           metadata.GrantRepository
+	Authz            *authz.Evaluator
 	Storage          storage.DiskEngine
 	Now              func() time.Time
 	NewID            func() string
@@ -66,11 +69,11 @@ func (h *ObjectHandlers) acquireUploadLock(uploadID string) func() {
 
 func (h *ObjectHandlers) PutObject(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
 		return
 	}
 
@@ -166,11 +169,11 @@ func (h *ObjectHandlers) HeadObject(w http.ResponseWriter, r *http.Request) {
 
 func (h *ObjectHandlers) DeleteObject(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
-	if !h.ensureBucket(w, r, bucketName) {
-		return
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionDeleteObject, key, "") {
 		return
 	}
 

--- a/internal/s3/object_handlers_test.go
+++ b/internal/s3/object_handlers_test.go
@@ -35,6 +35,7 @@ type objectTestEnv struct {
 	buckets          metadata.BucketRepository
 	objects          metadata.ObjectRepository
 	multipartUploads metadata.MultipartUploadRepository
+	grants           metadata.GrantRepository
 	storage          storage.DiskEngine
 	sigv4            auth.SigV4Credentials
 	signer           *publicread.Signer
@@ -82,11 +83,14 @@ func newObjectTestEnv(t *testing.T) objectTestEnv {
 		t.Fatalf("new public read signer: %v", err)
 	}
 	multipartRepo := metadata.NewMultipartUploadRepository(db)
+	grantRepo := metadata.NewGrantRepository(db)
 	handlers := &ObjectHandlers{
 		Users:            userRepo,
 		Buckets:          bucketRepo,
 		Objects:          objectRepo,
 		MultipartUploads: multipartRepo,
+		Grants:           grantRepo,
+		Authz:            NewAuthzEvaluator(grantRepo),
 		Storage:          disk,
 		Now:              func() time.Time { return now },
 		NewID:            newSequentialID(),
@@ -114,6 +118,7 @@ func newObjectTestEnv(t *testing.T) objectTestEnv {
 		buckets:          bucketRepo,
 		objects:          objectRepo,
 		multipartUploads: multipartRepo,
+		grants:           grantRepo,
 		storage:          disk,
 		sigv4:            sigv4,
 		signer:           signer,

--- a/internal/s3/object_read.go
+++ b/internal/s3/object_read.go
@@ -7,16 +7,17 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
 	"github.com/i-got-this-faa/fbs/internal/storage"
 )
 
 func (h *ObjectHandlers) loadObjectForRead(w http.ResponseWriter, r *http.Request, bucketName, key string) (*metadata.Object, bool) {
-	if !h.ensureBucket(w, r, bucketName) {
-		return nil, false
-	}
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return nil, false
+	}
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionGetObject, key, "") {
 		return nil, false
 	}
 

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -187,6 +187,37 @@ BEGIN
 END;
 `,
 	},
+	{
+		version: 8,
+		name:    "add resource grants",
+		sql: `
+CREATE TABLE IF NOT EXISTS grants (
+    id              TEXT PRIMARY KEY,
+    bucket_name     TEXT NOT NULL REFERENCES buckets(name) ON DELETE CASCADE,
+    grantee_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    action          TEXT NOT NULL,
+    key_prefix      TEXT NOT NULL DEFAULT '',
+    is_active       INTEGER NOT NULL DEFAULT 1,
+    created_by      TEXT REFERENCES users(id) ON DELETE SET NULL,
+    note            TEXT,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_grants_unique_active
+    ON grants(bucket_name, grantee_user_id, action, key_prefix)
+    WHERE is_active = 1;
+
+CREATE INDEX IF NOT EXISTS idx_grants_bucket_grantee
+    ON grants(bucket_name, grantee_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_grants_grantee
+    ON grants(grantee_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_grants_bucket
+    ON grants(bucket_name);
+`,
+	},
 }
 
 func ensureMigrationsTable(db *sql.DB) error {

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -64,8 +64,8 @@ func TestRun_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 7 {
-		t.Errorf("migration count = %d, want 7", count)
+	if count != 8 {
+		t.Errorf("migration count = %d, want 8", count)
 	}
 }
 
@@ -157,8 +157,8 @@ func TestRun_BootstrapFromInitSQL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 7 {
-		t.Errorf("migration count = %d, want 7", count)
+	if count != 8 {
+		t.Errorf("migration count = %d, want 8", count)
 	}
 
 	// Verify sigv4 columns were added by v2

--- a/plan/s3-compatibility.md
+++ b/plan/s3-compatibility.md
@@ -52,7 +52,7 @@ plane). That is intentional and **not** full AWS IAM.
 | Feature | Status | Notes |
 |---|---|---|
 | Admin / member roles + ownership | Implemented | Owner short-circuit on owned buckets |
-| Mini-IAM resource grants (Management API) | Planned (grants) | See access-control design; not S3 `?policy` |
+| Mini-IAM resource grants (Management API) | Implemented | Fixed actions + optional key prefix; not S3 `?policy` |
 | ACLs (`?acl`) | Permanent non-goal | Ownership is first-class; ACL protocol not used |
 | Bucket policies (`?policy`) | Permanent non-goal | Grants only; no AWS policy language evaluator |
 | AWS IAM users / groups / roles / identity policies | Permanent non-goal | Principals live in local `users` table |


### PR DESCRIPTION
## Summary

- Adds mini-IAM **resource grants** (fixed `s3:*` actions, optional key prefix) as designed in `plan/access-control/access-control.md`
- Introduces `internal/authz` evaluator (admin → owner → active grant → deny) and migration 8 (`grants` table)
- Wires S3 data-plane handlers through action-based authorization; ListBuckets returns owned ∪ granted buckets
- Management API grant CRUD + ownership transfer (admin or bucket owner; `GET /grants/me` for self)
- Updates docs; unit tests cover evaluator, grant store, management, and grant-scoped S3 access

## Test plan

- [x] `go test ./...`
- [x] gopls check on changed packages
- [x] `./compat/s3-tests/run.sh --keep` (core filter; AWS IAM/policy/STS remain permanent non-goals)

## Notes

This is intentionally **not** AWS IAM, bucket policies, ACLs, or STS. Sharing is Management grants only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Management API support for resource grants, including creation, updates, deletion, listing, and ownership transfers.
  * Added grant-based S3 access with action and key-prefix controls.
  * Bucket listings now include buckets shared through active grants.
* **Bug Fixes**
  * Improved authorization for object, bucket, copy, multipart, and batch-delete operations.
  * Unauthorized batch deletions now report per-object errors.
* **Documentation**
  * Updated API, authentication, architecture, and development guidance for grants and access rules.
* **Tests**
  * Added coverage for grant management, ownership transfers, prefix restrictions, and S3 authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->