### PR TITLE
Enhance S3 compatibility with documentation and multipart metadata

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/i-got-this-faa/fbs/internal/server"
 	"github.com/i-got-this-faa/fbs/internal/setup"
 	"github.com/i-got-this-faa/fbs/internal/storage"
+	appmiddleware "github.com/i-got-this-faa/fbs/internal/http/middleware"
 )
 
 func main() {
@@ -170,11 +171,13 @@ func main() {
 			})
 		})
 		r.Group(func(s3Routes chi.Router) {
+			s3Routes.Use(appmiddleware.S3Headers)
 			s3Routes.Use(auth.RequireAuthentication(authChain, writeS3AuthError))
 			s3.RegisterBucketRoutes(s3Routes, objectHandlers)
 			s3.RegisterObjectReadRoutes(s3Routes, objectHandlers)
 		})
 		r.Group(func(s3Routes chi.Router) {
+			s3Routes.Use(appmiddleware.S3Headers)
 			s3Routes.Use(auth.RequireAuthentication(authChain, writeS3AuthError))
 			s3.RegisterObjectMutationRoutes(s3Routes, objectHandlers)
 		})

--- a/compat/s3-tests/README.md
+++ b/compat/s3-tests/README.md
@@ -32,12 +32,10 @@ From the **repository root**:
 
 ```bash
 # 1) Run the core compatibility suite (managed temporary server)
-./compat/s3-tests/run.sh --keep 2>&1 | tee compat/s3-tests/results/last-run.log
+#    --keep preserves data/logs for inspection
+./compat/s3-tests/run.sh --keep
 
-# 2) Build / refresh the feature checklist from that log
-./compat/s3-tests/report.sh compat/s3-tests/results/last-run.log
-
-# 3) View results
+# 2) View results
 #    - Markdown: compat/s3-tests/results/checklist.md
 #    - Browser:  open compat/s3-tests/results/checklist.html
 xdg-open compat/s3-tests/results/checklist.html   # optional

--- a/compat/s3-tests/lib/marker-expr.sh
+++ b/compat/s3-tests/lib/marker-expr.sh
@@ -1,0 +1,13 @@
+# Shared awk-based marker expression builder.
+# Usage:  build_marker_expr <markers-file>
+build_marker_expr() {
+  awk '
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*$/ { next }
+    {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+      if (n++) printf " and "
+      printf "%s", $0
+    }
+  ' "${1}"
+}

--- a/compat/s3-tests/patches/apply-nuke-fallback.py
+++ b/compat/s3-tests/patches/apply-nuke-fallback.py
@@ -58,16 +58,24 @@ def nuke_bucket(client, bucket):
     """Best-effort empty + delete for non-versioning servers."""
     batch_size = 128
     for objects in list_versions(client, bucket, batch_size):
-        keys = [{{'Key': o['Key']}} for o in objects]
+        keys = []
+        for o in objects:
+            entry = {{'Key': o['Key']}}
+            if 'VersionId' in o and o.get('VersionId'):
+                entry['VersionId'] = o['VersionId']
+            keys.append(entry)
         try:
             client.delete_objects(
                 Bucket=bucket,
                 Delete={{'Objects': keys, 'Quiet': True}},
             )
         except ClientError:
-            for obj in keys:
+            for obj in objects:
+                kwargs = {{'Bucket': bucket, 'Key': obj['Key']}}
+                if 'VersionId' in obj and obj.get('VersionId'):
+                    kwargs['VersionId'] = obj['VersionId']
                 try:
-                    client.delete_object(Bucket=bucket, Key=obj['Key'])
+                    client.delete_object(**kwargs)
                 except ClientError:
                     pass
 

--- a/compat/s3-tests/report.sh
+++ b/compat/s3-tests/report.sh
@@ -12,8 +12,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKDIR="${FBS_S3_TESTS_WORKDIR:-${SCRIPT_DIR}/.workdir}"
+MODE="core"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --core) MODE="core"; shift ;;
+    --full) MODE="full"; shift ;;
+    --) shift; break ;;
+    *) break ;;
+  esac
+done
 LOG="${1:-}"
+WORKDIR="${FBS_S3_TESTS_WORKDIR:-${SCRIPT_DIR}/.workdir}"
 OUT_DIR="${SCRIPT_DIR}/results"
 MARKERS_FILE="${SCRIPT_DIR}/markers.core"
 S3_TESTS_DIR="${WORKDIR}/s3-tests"
@@ -39,15 +48,8 @@ mkdir -p "${OUT_DIR}"
 # shellcheck disable=SC1091
 source "${VENV_DIR}/bin/activate"
 
-MARKER_EXPR="$(awk '
-  /^[[:space:]]*#/ { next }
-  /^[[:space:]]*$/ { next }
-  {
-    gsub(/^[[:space:]]+|[[:space:]]+$/, "")
-    if (n++) printf " and "
-    printf "%s", $0
-  }
-' "${MARKERS_FILE}")"
+  source "${SCRIPT_DIR}/lib/marker-expr.sh"
+  MARKER_EXPR="$(build_marker_expr "${MARKERS_FILE}")"
 
 # Prefer conf from workdir if present (collect-only still reads S3TEST_CONF)
 export S3TEST_CONF="${WORKDIR}/s3tests.conf"
@@ -110,8 +112,14 @@ COLLECT="${OUT_DIR}/selected-tests.txt"
   else
     PY=python
   fi
-  "${PY}" -m pytest --collect-only -q -m "${MARKER_EXPR}" s3tests/functional 2>/dev/null \
-    | awk '/^s3tests\// {print}' >"${COLLECT}"
+  if [[ "${MODE}" == "core" ]]; then
+    "${PY}" -m pytest --collect-only -q -m "${MARKER_EXPR}" \
+      s3tests/functional/test_s3.py s3tests/functional/test_headers.py s3tests/functional/test_utils.py 2>/dev/null \
+      | awk '/^s3tests\// {print}' >"${COLLECT}"
+  else
+    "${PY}" -m pytest --collect-only -q -m "${MARKER_EXPR}" s3tests/functional 2>/dev/null \
+      | awk '/^s3tests\// {print}' >"${COLLECT}"
+  fi
 )
 
 python3 - "${LOG}" "${COLLECT}" "${OUT_DIR}" <<'PY'
@@ -151,8 +159,18 @@ for line in log.splitlines():
             rest = rest.split(" - ", 1)[0]
         errored.add(rest.strip())
 
-failed_m = {s for s in selected if s in failed or any(s.startswith(f) or f.startswith(s) for f in failed)}
-errored_m = {s for s in selected if s in errored or any(s.startswith(e) or e.startswith(s) for e in errored)}
+def _matches(selected, failed):
+    # exact match
+    if selected == failed:
+        return True
+    # bracket-suffix variance: nodeid[param]
+    bracket = selected.find("[")
+    if bracket >= 0 and selected[:bracket] == failed:
+        return True
+    return False
+
+failed_m = {s for s in selected if any(_matches(s, f) for f in failed)}
+errored_m = {s for s in selected if any(_matches(s, e) for e in errored)}
 passed = [s for s in selected if s not in failed_m and s not in errored_m]
 
 def test_name(nodeid: str) -> str:
@@ -179,11 +197,11 @@ def category(nodeid: str) -> str:
         ("Copy Object", [r"copy_obj", r"copy_object", r"upload_part_copy"]),
         ("Checksums", [r"checksum", r"cksum", r"content_md5", r"bad_md5", r"sha256", r"sha1", r"crc32", r"crc64"]),
         ("List Objects", [r"bucket_list", r"listv2", r"list_objects", r"delimiter", r"prefix", r"marker", r"pagination", r"encoding", r"key_count", r"list_many", r"list_empty", r"list_distinct"]),
+        ("Conditional Requests", [r"ifmatch", r"ifnonematch", r"if_match", r"if_none", r"ifmodified"]),
+        ("Object Attributes / Torrent", [r"object_attributes", r"torrent"]),
         ("Get / Head / Range", [r"ranged", r"range_request", r"get_object", r"head_object", r"read_unreadable", r"object_read"]),
         ("Put / Delete Object", [r"object_create", r"put_object", r"delete_object", r"multi_object_delete", r"object_write", r"object_delete"]),
         ("Bucket Ops", [r"bucket_create", r"bucket_delete", r"bucket_head", r"location", r"bucket_notexist", r"bucket_recreate"]),
-        ("Conditional Requests", [r"ifmatch", r"ifnonematch", r"if_match", r"if_none", r"ifmodified"]),
-        ("Object Attributes / Torrent", [r"object_attributes", r"torrent"]),
         ("Tagging", [r"tagging", r"\btag_"]),
         ("Lifecycle", [r"lifecycle"]),
         ("Encryption / SSE", [r"sse_", r"encryption", r"\bkms\b"]),
@@ -197,10 +215,11 @@ def category(nodeid: str) -> str:
     return "Other / Uncategorized"
 
 order = [
-    "Bucket Ops", "Put / Delete Object", "Get / Head / Range", "List Objects",
+    "Bucket Ops", "Conditional Requests", "Object Attributes / Torrent",
+    "Put / Delete Object", "Get / Head / Range", "List Objects",
     "Multipart Upload", "Copy Object", "Checksums", "Headers / Auth edge cases",
-    "Conditional Requests", "ACL / Public Access", "Bucket Policy", "Versioning",
-    "Object Lock / WORM", "Object Attributes / Torrent", "IAM / STS / OIDC",
+    "ACL / Public Access", "Bucket Policy", "Versioning",
+    "Object Lock / WORM", "IAM / STS / OIDC",
     "Tagging", "Lifecycle", "Encryption / SSE", "Website", "Logging",
     "Utils / Misc", "Other / Uncategorized",
 ]

--- a/compat/s3-tests/run.sh
+++ b/compat/s3-tests/run.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 WORKDIR="${FBS_S3_TESTS_WORKDIR:-${SCRIPT_DIR}/.workdir}"
 S3_TESTS_DIR="${WORKDIR}/s3-tests"
 S3_TESTS_REPO="${FBS_S3_TESTS_REPO:-https://github.com/ceph/s3-tests.git}"
-S3_TESTS_REF="${FBS_S3_TESTS_REF:-master}"
+S3_TESTS_REF="${FBS_S3_TESTS_REF:-e3e1c240d}"
 MARKERS_FILE="${SCRIPT_DIR}/markers.core"
 SERVER_BIN="${WORKDIR}/fbs-server"
 SERVER_LOG="${WORKDIR}/fbs-server.log"
@@ -356,20 +356,7 @@ setup_python() {
   python -m pip install -q tox
 }
 
-build_marker_expr() {
-  if [[ ! -f "${MARKERS_FILE}" ]]; then
-    die "missing markers file: ${MARKERS_FILE}"
-  fi
-  awk '
-    /^[[:space:]]*#/ { next }
-    /^[[:space:]]*$/ { next }
-    {
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "")
-      if (n++) printf " and "
-      printf "%s", $0
-    }
-  ' "${MARKERS_FILE}"
-}
+source "${SCRIPT_DIR}/lib/marker-expr.sh"
 
 run_tests() {
   # shellcheck disable=SC1091
@@ -378,13 +365,16 @@ run_tests() {
 
   local args=()
   if [[ "${MODE}" == "core" ]]; then
+    if [[ ! -f "${MARKERS_FILE}" ]]; then
+      die "missing markers file: ${MARKERS_FILE}"
+    fi
     local expr
-    expr="$(build_marker_expr)"
+    expr="$(build_marker_expr "${MARKERS_FILE}")"
     args+=(-m "${expr}")
     # Default path: boto3 functional suite. IAM/STS modules excluded by markers
     # and by not selecting those files when no explicit pytest args are given.
     if [[ ${#PYTEST_ARGS[@]} -eq 0 ]]; then
-      args+=(s3tests/functional)
+      args+=(s3tests/functional/test_s3.py s3tests/functional/test_headers.py s3tests/functional/test_utils.py)
     fi
   fi
   if [[ ${#PYTEST_ARGS[@]} -gt 0 ]]; then

--- a/internal/http/middleware/requestid.go
+++ b/internal/http/middleware/requestid.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"net/http"
+	"time"
 )
 
 type requestIDKey struct{}
@@ -26,6 +28,9 @@ func S3Headers(next http.Handler) http.Handler {
 
 func newRequestID() string {
 	b := make([]byte, 8)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil || len(b) != 8 {
+		// Fallback: time-based ID when crypto/rand fails.
+		return hex.EncodeToString([]byte(fmt.Sprintf("%d", time.Now().UnixNano())))
+	}
 	return hex.EncodeToString(b)
 }

--- a/internal/http/middleware/requestid.go
+++ b/internal/http/middleware/requestid.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+)
+
+type requestIDKey struct{}
+
+func GetRequestID(ctx context.Context) string {
+	v, _ := ctx.Value(requestIDKey{}).(string)
+	return v
+}
+
+func S3Headers(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := newRequestID()
+		ctx := context.WithValue(r.Context(), requestIDKey{}, id)
+		w.Header().Set("x-amz-request-id", id)
+		w.Header().Set("x-amz-id-2", id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func newRequestID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/metadata/multipart.go
+++ b/internal/metadata/multipart.go
@@ -523,7 +523,7 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE bucket_name = ?
-		  AND (? = '' OR (substr(key, 1, length(?)) = ? AND key < ?))
+		  AND (? = '' OR substr(key, 1, length(?)) = ?)
 		  AND (key > ? OR (key = ? AND id > ?))
 		ORDER BY key, id
 		LIMIT ?`
@@ -531,7 +531,7 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 	// We query maxUploads+1 to detect truncation.
 	limit := maxUploads + 1
 
-	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, prefix, prefix, prefix+"zzzzzzzz", keyMarker, keyMarker, uploadIDMarker, limit)
+	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, prefix, prefix, keyMarker, keyMarker, uploadIDMarker, limit)
 	if err != nil {
 		return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket: %w", err)
 	}

--- a/internal/metadata/multipart.go
+++ b/internal/metadata/multipart.go
@@ -9,7 +9,6 @@ import (
 	"time"
 )
 // MultipartUpload represents a row in the multipart_uploads table.
-// MultipartUpload represents a row in the multipart_uploads table.
 type MultipartUpload struct {
 	ID                string
 	BucketName        string
@@ -523,15 +522,16 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE bucket_name = ?
+		  AND status = 'active'
 		  AND (? = '' OR substr(key, 1, length(?)) = ?)
-		  AND (key > ? OR (key = ? AND id > ?))
+		  AND (key, id) > (?, ?)
 		ORDER BY key, id
 		LIMIT ?`
 
 	// We query maxUploads+1 to detect truncation.
 	limit := maxUploads + 1
 
-	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, prefix, prefix, keyMarker, keyMarker, uploadIDMarker, limit)
+	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, prefix, prefix, keyMarker, uploadIDMarker, limit)
 	if err != nil {
 		return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket: %w", err)
 	}

--- a/internal/metadata/multipart.go
+++ b/internal/metadata/multipart.go
@@ -498,7 +498,7 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE bucket_name = ?
-		  AND key >= COALESCE(NULLIF(?, ''), key)
+		  AND (? = '' OR key LIKE ? || '%')
 		  AND (key > ? OR (key = ? AND id > ?))
 		ORDER BY key, id
 		LIMIT ?`

--- a/internal/metadata/multipart.go
+++ b/internal/metadata/multipart.go
@@ -3,30 +3,38 @@ package metadata
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 )
-
+// MultipartUpload represents a row in the multipart_uploads table.
 // MultipartUpload represents a row in the multipart_uploads table.
 type MultipartUpload struct {
-	ID              string
-	BucketName      string
-	Key             string
-	ContentType     string
-	Status          string
-	CreatedAt       time.Time
-	StatusUpdatedAt time.Time
+	ID                string
+	BucketName        string
+	Key               string
+	ContentType       string
+	ChecksumAlgorithm string
+	Status            string
+	CreatedAt         time.Time
+	StatusUpdatedAt   time.Time
+	UserMetadata      map[string]string
 }
 
 // MultipartPart represents a row in the multipart_parts table.
 type MultipartPart struct {
-	UploadID    string
-	PartNumber  int
-	Size        int64
-	ETag        string
-	StoragePath string
-	CreatedAt   time.Time
+	UploadID         string
+	PartNumber       int
+	Size             int64
+	ETag             string
+	StoragePath      string
+	CreatedAt        time.Time
+	ChecksumCRC32    string
+	ChecksumCRC32C   string
+	ChecksumCRC64NVME string
+	ChecksumSHA1     string
+	ChecksumSHA256   string
 }
 
 // MultipartUploadRepository defines CRUD operations for multipart uploads.
@@ -55,6 +63,9 @@ type MultipartUploadRepository interface {
 	// SetUploadStatus unconditionally sets the upload status.
 	// Returns ErrMultipartUploadNotFound if the upload does not exist.
 	SetUploadStatus(ctx context.Context, uploadID string, status string) error
+	// ListByBucket returns multipart uploads in a bucket, with optional filtering
+	// and pagination. maxUploads is clamped to 1–1000.
+	ListByBucket(ctx context.Context, bucketName string, prefix, keyMarker, uploadIDMarker string, maxUploads int) (uploads []MultipartUpload, isTruncated bool, nextKeyMarker string, nextUploadIDMarker string, err error)
 }
 
 // ErrMultipartUploadNotFound is returned when an upload lookup yields no rows.
@@ -81,8 +92,8 @@ func NewMultipartUploadRepository(db *sql.DB) MultipartUploadRepository {
 
 func (r *sqliteMultipartUploadRepository) Create(ctx context.Context, upload *MultipartUpload) error {
 	const q = `
-		INSERT INTO multipart_uploads (id, bucket_name, key, content_type, status, created_at, status_updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`
+		INSERT INTO multipart_uploads (id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	if upload.ContentType == "" {
 		upload.ContentType = "application/octet-stream"
@@ -100,12 +111,13 @@ func (r *sqliteMultipartUploadRepository) Create(ctx context.Context, upload *Mu
 		upload.StatusUpdatedAt = upload.CreatedAt
 	}
 
-	createdAt := upload.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = time.Now().UTC()
+
+	metaJSON, err := json.Marshal(upload.UserMetadata)
+	if err != nil {
+		return fmt.Errorf("marshal user metadata: %w", err)
 	}
 
-	_, err := r.db.ExecContext(ctx, q,
+	_, err = r.db.ExecContext(ctx, q,
 		upload.ID,
 		upload.BucketName,
 		upload.Key,
@@ -113,6 +125,8 @@ func (r *sqliteMultipartUploadRepository) Create(ctx context.Context, upload *Mu
 		upload.Status,
 		upload.CreatedAt.UTC(),
 		upload.StatusUpdatedAt.UTC(),
+		upload.ChecksumAlgorithm,
+		string(metaJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("create multipart upload: %w", err)
@@ -123,7 +137,7 @@ func (r *sqliteMultipartUploadRepository) Create(ctx context.Context, upload *Mu
 
 func (r *sqliteMultipartUploadRepository) GetByID(ctx context.Context, id string) (*MultipartUpload, error) {
 	const q = `
-		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at
+		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE id = ?`
 
@@ -152,7 +166,7 @@ func (r *sqliteMultipartUploadRepository) Delete(ctx context.Context, id string)
 
 func (r *sqliteMultipartUploadRepository) ListStale(ctx context.Context, olderThan time.Time) ([]MultipartUpload, error) {
 	const q = `
-		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at
+		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE (status = ? AND created_at < ?)
 		   OR (status <> ? AND status_updated_at < ?)
@@ -322,13 +336,20 @@ func (r *sqliteMultipartUploadRepository) AddPart(ctx context.Context, part *Mul
 	}
 
 	const q = `
-		INSERT INTO multipart_parts (upload_id, part_number, size, etag, storage_path, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO multipart_parts (upload_id, part_number, size, etag, storage_path, created_at,
+			checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256)
+		VALUES (?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?)
 		ON CONFLICT(upload_id, part_number) DO UPDATE SET
 			size = excluded.size,
 			etag = excluded.etag,
 			storage_path = excluded.storage_path,
-			created_at = excluded.created_at`
+			created_at = excluded.created_at,
+			checksum_crc32 = excluded.checksum_crc32,
+			checksum_crc32c = excluded.checksum_crc32c,
+			checksum_crc64nvme = excluded.checksum_crc64nvme,
+			checksum_sha1 = excluded.checksum_sha1,
+			checksum_sha256 = excluded.checksum_sha256`
 
 	if part.CreatedAt.IsZero() {
 		part.CreatedAt = time.Now().UTC()
@@ -341,6 +362,11 @@ func (r *sqliteMultipartUploadRepository) AddPart(ctx context.Context, part *Mul
 		part.ETag,
 		part.StoragePath,
 		part.CreatedAt.UTC(),
+		nullify(part.ChecksumCRC32),
+		nullify(part.ChecksumCRC32C),
+		nullify(part.ChecksumCRC64NVME),
+		nullify(part.ChecksumSHA1),
+		nullify(part.ChecksumSHA256),
 	); err != nil {
 		return "", fmt.Errorf("add multipart part: %w", err)
 	}
@@ -435,7 +461,8 @@ func (r *sqliteMultipartUploadRepository) CompleteUpload(ctx context.Context, ob
 
 func (r *sqliteMultipartUploadRepository) ListParts(ctx context.Context, uploadID string) ([]MultipartPart, error) {
 	const q = `
-		SELECT upload_id, part_number, size, etag, storage_path, created_at
+		SELECT upload_id, part_number, size, etag, storage_path, created_at,
+			checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256
 		FROM multipart_parts
 		WHERE upload_id = ?
 		ORDER BY part_number ASC`
@@ -462,11 +489,58 @@ func (r *sqliteMultipartUploadRepository) ListParts(ctx context.Context, uploadI
 	return parts, nil
 }
 
+func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, bucketName string, prefix, keyMarker, uploadIDMarker string, maxUploads int) ([]MultipartUpload, bool, string, string, error) {
+	if maxUploads <= 0 || maxUploads > 1000 {
+		maxUploads = 1000
+	}
+
+	const q = `
+		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
+		FROM multipart_uploads
+		WHERE bucket_name = ?
+		  AND key >= COALESCE(NULLIF(?, ''), key)
+		  AND (key > ? OR (key = ? AND id > ?))
+		ORDER BY key, id
+		LIMIT ?`
+
+	// We query maxUploads+1 to detect truncation.
+	limit := maxUploads + 1
+
+	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, keyMarker, keyMarker, uploadIDMarker, limit)
+	if err != nil {
+		return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket: %w", err)
+	}
+	defer rows.Close()
+
+	var uploads []MultipartUpload
+	for rows.Next() {
+		u, err := scanMultipartUploadRow(rows)
+		if err != nil {
+			return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket scan: %w", err)
+		}
+		uploads = append(uploads, *u)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket rows: %w", err)
+	}
+
+	isTruncated := len(uploads) > maxUploads
+	if isTruncated {
+		uploads = uploads[:maxUploads]
+		last := uploads[len(uploads)-1]
+		return uploads, true, last.Key, last.ID, nil
+	}
+
+	return uploads, false, "", "", nil
+}
+
 func scanMultipartUpload(row *sql.Row) (*MultipartUpload, error) {
 	var u MultipartUpload
 	var createdAt, statusUpdatedAt string
+	var metaStr sql.NullString
 
-	err := row.Scan(&u.ID, &u.BucketName, &u.Key, &u.ContentType, &u.Status, &createdAt, &statusUpdatedAt)
+	err := row.Scan(&u.ID, &u.BucketName, &u.Key, &u.ContentType, &u.Status, &createdAt, &statusUpdatedAt, &u.ChecksumAlgorithm, &metaStr)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrMultipartUploadNotFound
 	}
@@ -483,14 +557,21 @@ func scanMultipartUpload(row *sql.Row) (*MultipartUpload, error) {
 		return nil, err
 	}
 
+	if metaStr.Valid && metaStr.String != "" {
+		if err := json.Unmarshal([]byte(metaStr.String), &u.UserMetadata); err != nil {
+			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
+		}
+	}
+
 	return &u, nil
 }
 
 func scanMultipartUploadRow(rows *sql.Rows) (*MultipartUpload, error) {
 	var u MultipartUpload
 	var createdAt, statusUpdatedAt string
+	var metaStr sql.NullString
 
-	if err := rows.Scan(&u.ID, &u.BucketName, &u.Key, &u.ContentType, &u.Status, &createdAt, &statusUpdatedAt); err != nil {
+	if err := rows.Scan(&u.ID, &u.BucketName, &u.Key, &u.ContentType, &u.Status, &createdAt, &statusUpdatedAt, &u.ChecksumAlgorithm, &metaStr); err != nil {
 		return nil, fmt.Errorf("scan multipart upload row: %w", err)
 	}
 
@@ -504,16 +585,33 @@ func scanMultipartUploadRow(rows *sql.Rows) (*MultipartUpload, error) {
 		return nil, err
 	}
 
+	if metaStr.Valid && metaStr.String != "" {
+		if err := json.Unmarshal([]byte(metaStr.String), &u.UserMetadata); err != nil {
+			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
+		}
+	}
+
 	return &u, nil
 }
+
+
 
 func scanMultipartPartRow(rows *sql.Rows) (*MultipartPart, error) {
 	var p MultipartPart
 	var createdAt string
+	var csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256 sql.NullString
 
-	if err := rows.Scan(&p.UploadID, &p.PartNumber, &p.Size, &p.ETag, &p.StoragePath, &createdAt); err != nil {
+	if err := rows.Scan(&p.UploadID, &p.PartNumber, &p.Size, &p.ETag, &p.StoragePath, &createdAt,
+		&csCRC32, &csCRC32C, &csCRC64NVME, &csSHA1, &csSHA256,
+	); err != nil {
 		return nil, fmt.Errorf("scan multipart part row: %w", err)
 	}
+
+	p.ChecksumCRC32 = csCRC32.String
+	p.ChecksumCRC32C = csCRC32C.String
+	p.ChecksumCRC64NVME = csCRC64NVME.String
+	p.ChecksumSHA1 = csSHA1.String
+	p.ChecksumSHA256 = csSHA256.String
 
 	var err error
 	p.CreatedAt, err = parseTimestamp(createdAt)
@@ -531,4 +629,12 @@ func validMultipartUploadStatus(status string) bool {
 	default:
 		return false
 	}
+}
+
+// nullify returns nil for empty strings so they are stored as NULL in the database.
+func nullify(s string) interface{} {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/internal/metadata/multipart.go
+++ b/internal/metadata/multipart.go
@@ -419,8 +419,10 @@ func (r *sqliteMultipartUploadRepository) CompleteUpload(ctx context.Context, ob
 	}
 
 	const createQ = `
-		INSERT INTO objects (id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO objects (id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at,
+			is_multipart, parts_count, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, user_metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(bucket_name, key) DO UPDATE SET
 			id = excluded.id,
 			size = excluded.size,
@@ -428,7 +430,15 @@ func (r *sqliteMultipartUploadRepository) CompleteUpload(ctx context.Context, ob
 			content_type = excluded.content_type,
 			storage_path = excluded.storage_path,
 			created_at = excluded.created_at,
-			updated_at = excluded.updated_at`
+			updated_at = excluded.updated_at,
+			is_multipart = excluded.is_multipart,
+			parts_count = excluded.parts_count,
+			checksum_crc32 = excluded.checksum_crc32,
+			checksum_crc32c = excluded.checksum_crc32c,
+			checksum_crc64nvme = excluded.checksum_crc64nvme,
+			checksum_sha1 = excluded.checksum_sha1,
+			checksum_sha256 = excluded.checksum_sha256,
+			user_metadata = excluded.user_metadata`
 
 	if obj.CreatedAt.IsZero() {
 		obj.CreatedAt = time.Now().UTC()
@@ -438,9 +448,24 @@ func (r *sqliteMultipartUploadRepository) CompleteUpload(ctx context.Context, ob
 	}
 	now := obj.CreatedAt.UTC()
 
+	var metaStr *string
+	if len(obj.UserMetadata) > 0 {
+		b, err := json.Marshal(obj.UserMetadata)
+		if err != nil {
+			return "", fmt.Errorf("marshal user metadata: %w", err)
+		}
+		s := string(b)
+		metaStr = &s
+	}
+
+
 	if _, err := conn.ExecContext(ctx, createQ,
 		obj.ID, obj.BucketName, obj.Key, obj.Size, obj.ETag,
 		obj.ContentType, obj.StoragePath, now, obj.UpdatedAt.UTC(),
+		obj.IsMultipart, obj.PartsCount,
+		nullify(obj.ChecksumCRC32), nullify(obj.ChecksumCRC32C), nullify(obj.ChecksumCRC64NVME),
+		nullify(obj.ChecksumSHA1), nullify(obj.ChecksumSHA256),
+		metaStr,
 	); err != nil {
 		return "", fmt.Errorf("create object: %w", err)
 	}
@@ -498,7 +523,7 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 		SELECT id, bucket_name, key, content_type, status, created_at, status_updated_at, checksum_algorithm, user_metadata
 		FROM multipart_uploads
 		WHERE bucket_name = ?
-		  AND (? = '' OR key LIKE ? || '%')
+		  AND (? = '' OR (substr(key, 1, length(?)) = ? AND key < ?))
 		  AND (key > ? OR (key = ? AND id > ?))
 		ORDER BY key, id
 		LIMIT ?`
@@ -506,7 +531,7 @@ func (r *sqliteMultipartUploadRepository) ListByBucket(ctx context.Context, buck
 	// We query maxUploads+1 to detect truncation.
 	limit := maxUploads + 1
 
-	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, keyMarker, keyMarker, uploadIDMarker, limit)
+	rows, err := r.db.QueryContext(ctx, q, bucketName, prefix, prefix, prefix, prefix+"zzzzzzzz", keyMarker, keyMarker, uploadIDMarker, limit)
 	if err != nil {
 		return nil, false, "", "", fmt.Errorf("list multipart uploads by bucket: %w", err)
 	}

--- a/internal/metadata/multipart_test.go
+++ b/internal/metadata/multipart_test.go
@@ -15,11 +15,13 @@ CREATE TABLE IF NOT EXISTS multipart_uploads (
     id           TEXT PRIMARY KEY,
     bucket_name  TEXT NOT NULL REFERENCES buckets(name),
     key          TEXT NOT NULL,
-	    content_type TEXT NOT NULL DEFAULT 'application/octet-stream',
-	    status       TEXT NOT NULL DEFAULT 'active',
-	    created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	    status_updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-	);
+    content_type TEXT NOT NULL DEFAULT 'application/octet-stream',
+    status       TEXT NOT NULL DEFAULT 'active',
+    created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    status_updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    checksum_algorithm TEXT,
+    user_metadata TEXT
+);
 
 CREATE TABLE IF NOT EXISTS multipart_parts (
     upload_id   TEXT NOT NULL REFERENCES multipart_uploads(id) ON DELETE CASCADE,
@@ -28,6 +30,11 @@ CREATE TABLE IF NOT EXISTS multipart_parts (
     etag        TEXT NOT NULL,
     storage_path TEXT NOT NULL,
     created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    checksum_crc32 TEXT,
+    checksum_crc32c TEXT,
+    checksum_crc64nvme TEXT,
+    checksum_sha1 TEXT,
+    checksum_sha256 TEXT,
     PRIMARY KEY (upload_id, part_number)
 );
 `

--- a/internal/metadata/objects.go
+++ b/internal/metadata/objects.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"encoding/json"
 	"time"
 )
 
-// Object represents a row in the objects table.
 type Object struct {
 	ID          string
 	BucketName  string
@@ -19,6 +19,14 @@ type Object struct {
 	StoragePath string
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
+	IsMultipart bool
+	PartsCount  int
+	ChecksumCRC32    string
+	ChecksumCRC32C   string
+	ChecksumCRC64NVME string
+	ChecksumSHA1     string
+	ChecksumSHA256   string
+	UserMetadata map[string]string
 }
 
 // DelimitedListEntry is one result row from ListDelimited. VirtualKey holds
@@ -59,11 +67,12 @@ type sqliteObjectRepository struct {
 func NewObjectRepository(db *sql.DB) ObjectRepository {
 	return &sqliteObjectRepository{db: db}
 }
-
 func (r *sqliteObjectRepository) Create(ctx context.Context, obj *Object) error {
 	const q = `
-		INSERT INTO objects (id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO objects (id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at,
+			is_multipart, parts_count, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, user_metadata)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(bucket_name, key) DO UPDATE SET
 			id = excluded.id,
 			size = excluded.size,
@@ -71,7 +80,15 @@ func (r *sqliteObjectRepository) Create(ctx context.Context, obj *Object) error 
 			content_type = excluded.content_type,
 			storage_path = excluded.storage_path,
 			created_at = excluded.created_at,
-			updated_at = excluded.updated_at`
+			updated_at = excluded.updated_at,
+			is_multipart = excluded.is_multipart,
+			parts_count = excluded.parts_count,
+			checksum_crc32 = excluded.checksum_crc32,
+			checksum_crc32c = excluded.checksum_crc32c,
+			checksum_crc64nvme = excluded.checksum_crc64nvme,
+			checksum_sha1 = excluded.checksum_sha1,
+			checksum_sha256 = excluded.checksum_sha256,
+			user_metadata = excluded.user_metadata`
 
 	if obj.CreatedAt.IsZero() {
 		obj.CreatedAt = time.Now().UTC()
@@ -80,6 +97,16 @@ func (r *sqliteObjectRepository) Create(ctx context.Context, obj *Object) error 
 		obj.UpdatedAt = obj.CreatedAt
 	}
 	now := obj.CreatedAt.UTC()
+
+	var metaStr *string
+	if len(obj.UserMetadata) > 0 {
+		b, err := json.Marshal(obj.UserMetadata)
+		if err != nil {
+			return fmt.Errorf("marshal user metadata: %w", err)
+		}
+		s := string(b)
+		metaStr = &s
+	}
 
 	_, err := r.db.ExecContext(ctx, q,
 		obj.ID,
@@ -91,6 +118,14 @@ func (r *sqliteObjectRepository) Create(ctx context.Context, obj *Object) error 
 		obj.StoragePath,
 		now,
 		obj.UpdatedAt.UTC(),
+		obj.IsMultipart,
+		obj.PartsCount,
+		obj.ChecksumCRC32,
+		obj.ChecksumCRC32C,
+		obj.ChecksumCRC64NVME,
+		obj.ChecksumSHA1,
+		obj.ChecksumSHA256,
+		metaStr,
 	)
 	if err != nil {
 		return fmt.Errorf("create object: %w", err)
@@ -101,7 +136,8 @@ func (r *sqliteObjectRepository) Create(ctx context.Context, obj *Object) error 
 
 func (r *sqliteObjectRepository) GetByKey(ctx context.Context, bucketName, key string) (*Object, error) {
 	const q = `
-		SELECT id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at
+		SELECT id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at,
+			is_multipart, parts_count, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, user_metadata
 		FROM objects
 		WHERE bucket_name = ? AND key = ?`
 
@@ -113,9 +149,9 @@ func (r *sqliteObjectRepository) List(ctx context.Context, bucketName, prefix, s
 	if maxKeys <= 0 {
 		return []Object{}, false, nil
 	}
-
 	q := `
-		SELECT id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at
+		SELECT id, bucket_name, key, size, etag, content_type, storage_path, created_at, updated_at,
+			is_multipart, parts_count, checksum_crc32, checksum_crc32c, checksum_crc64nvme, checksum_sha1, checksum_sha256, user_metadata
 		FROM objects
 		WHERE bucket_name = ? AND key > ?`
 	args := []any{bucketName, startAfter}
@@ -298,14 +334,23 @@ func (r *sqliteObjectRepository) DeleteAllInBucket(ctx context.Context, bucketNa
 func scanObject(row *sql.Row) (*Object, error) {
 	var o Object
 	var createdAt, updatedAt string
+	var metaStr sql.NullString
+	var csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256 sql.NullString
 
-	err := row.Scan(&o.ID, &o.BucketName, &o.Key, &o.Size, &o.ETag, &o.ContentType, &o.StoragePath, &createdAt, &updatedAt)
+	err := row.Scan(&o.ID, &o.BucketName, &o.Key, &o.Size, &o.ETag, &o.ContentType, &o.StoragePath, &createdAt, &updatedAt,
+		&o.IsMultipart, &o.PartsCount, &csCRC32, &csCRC32C, &csCRC64NVME, &csSHA1, &csSHA256, &metaStr)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrObjectNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("scan object: %w", err)
 	}
+
+	o.ChecksumCRC32 = csCRC32.String
+	o.ChecksumCRC32C = csCRC32C.String
+	o.ChecksumCRC64NVME = csCRC64NVME.String
+	o.ChecksumSHA1 = csSHA1.String
+	o.ChecksumSHA256 = csSHA256.String
 
 	o.CreatedAt, err = parseTimestamp(createdAt)
 	if err != nil {
@@ -316,16 +361,31 @@ func scanObject(row *sql.Row) (*Object, error) {
 		return nil, err
 	}
 
+	if metaStr.Valid && metaStr.String != "" {
+		if err := json.Unmarshal([]byte(metaStr.String), &o.UserMetadata); err != nil {
+			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
+		}
+	}
+
 	return &o, nil
 }
 
 func scanObjectRow(rows *sql.Rows) (*Object, error) {
 	var o Object
 	var createdAt, updatedAt string
+	var metaStr sql.NullString
+	var csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256 sql.NullString
 
-	if err := rows.Scan(&o.ID, &o.BucketName, &o.Key, &o.Size, &o.ETag, &o.ContentType, &o.StoragePath, &createdAt, &updatedAt); err != nil {
+	if err := rows.Scan(&o.ID, &o.BucketName, &o.Key, &o.Size, &o.ETag, &o.ContentType, &o.StoragePath, &createdAt, &updatedAt,
+		&o.IsMultipart, &o.PartsCount, &csCRC32, &csCRC32C, &csCRC64NVME, &csSHA1, &csSHA256, &metaStr); err != nil {
 		return nil, fmt.Errorf("scan object row: %w", err)
 	}
+
+	o.ChecksumCRC32 = csCRC32.String
+	o.ChecksumCRC32C = csCRC32C.String
+	o.ChecksumCRC64NVME = csCRC64NVME.String
+	o.ChecksumSHA1 = csSHA1.String
+	o.ChecksumSHA256 = csSHA256.String
 
 	var err error
 	o.CreatedAt, err = parseTimestamp(createdAt)
@@ -337,5 +397,13 @@ func scanObjectRow(rows *sql.Rows) (*Object, error) {
 		return nil, err
 	}
 
+	if metaStr.Valid && metaStr.String != "" {
+		if err := json.Unmarshal([]byte(metaStr.String), &o.UserMetadata); err != nil {
+			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
+		}
+	}
+
 	return &o, nil
 }
+
+

--- a/internal/metadata/objects.go
+++ b/internal/metadata/objects.go
@@ -346,29 +346,37 @@ func scanObject(row *sql.Row) (*Object, error) {
 		return nil, fmt.Errorf("scan object: %w", err)
 	}
 
+	if err := applyScannedExtras(&o, createdAt, updatedAt, metaStr, csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256); err != nil {
+		return nil, err
+	}
+
+	return &o, nil
+}
+func applyScannedExtras(o *Object, createdAt, updatedAt string, metaStr sql.NullString, csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256 sql.NullString) error {
 	o.ChecksumCRC32 = csCRC32.String
 	o.ChecksumCRC32C = csCRC32C.String
 	o.ChecksumCRC64NVME = csCRC64NVME.String
 	o.ChecksumSHA1 = csSHA1.String
 	o.ChecksumSHA256 = csSHA256.String
 
+	var err error
 	o.CreatedAt, err = parseTimestamp(createdAt)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	o.UpdatedAt, err = parseTimestamp(updatedAt)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if metaStr.Valid && metaStr.String != "" {
 		if err := json.Unmarshal([]byte(metaStr.String), &o.UserMetadata); err != nil {
-			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
+			return fmt.Errorf("unmarshal user metadata: %w", err)
 		}
 	}
-
-	return &o, nil
+	return nil
 }
+
 
 func scanObjectRow(rows *sql.Rows) (*Object, error) {
 	var o Object
@@ -381,26 +389,8 @@ func scanObjectRow(rows *sql.Rows) (*Object, error) {
 		return nil, fmt.Errorf("scan object row: %w", err)
 	}
 
-	o.ChecksumCRC32 = csCRC32.String
-	o.ChecksumCRC32C = csCRC32C.String
-	o.ChecksumCRC64NVME = csCRC64NVME.String
-	o.ChecksumSHA1 = csSHA1.String
-	o.ChecksumSHA256 = csSHA256.String
-
-	var err error
-	o.CreatedAt, err = parseTimestamp(createdAt)
-	if err != nil {
+	if err := applyScannedExtras(&o, createdAt, updatedAt, metaStr, csCRC32, csCRC32C, csCRC64NVME, csSHA1, csSHA256); err != nil {
 		return nil, err
-	}
-	o.UpdatedAt, err = parseTimestamp(updatedAt)
-	if err != nil {
-		return nil, err
-	}
-
-	if metaStr.Valid && metaStr.String != "" {
-		if err := json.Unmarshal([]byte(metaStr.String), &o.UserMetadata); err != nil {
-			return nil, fmt.Errorf("unmarshal user metadata: %w", err)
-		}
 	}
 
 	return &o, nil

--- a/internal/metadata/objects_test.go
+++ b/internal/metadata/objects_test.go
@@ -21,9 +21,16 @@ CREATE TABLE IF NOT EXISTS objects (
     storage_path   TEXT NOT NULL,
     created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_multipart   INTEGER NOT NULL DEFAULT 0,
+    parts_count    INTEGER NOT NULL DEFAULT 0,
+    checksum_crc32 TEXT,
+    checksum_crc32c TEXT,
+    checksum_crc64nvme TEXT,
+    checksum_sha1 TEXT,
+    checksum_sha256 TEXT,
+    user_metadata  TEXT,
     UNIQUE(bucket_name, key)
 );
-
 CREATE INDEX IF NOT EXISTS idx_objects_bucket_prefix ON objects(bucket_name, key);
 `
 

--- a/internal/s3/bucket_delete.go
+++ b/internal/s3/bucket_delete.go
@@ -3,7 +3,9 @@ package s3
 import (
 	"errors"
 	"net/http"
-	"strings"
+
+	sqlite "modernc.org/sqlite"
+	lib "modernc.org/sqlite/lib"
 
 	"github.com/i-got-this-faa/fbs/internal/authz"
 	"github.com/i-got-this-faa/fbs/internal/metadata"
@@ -28,22 +30,29 @@ func (h *ObjectHandlers) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 
 	// Abort any pending multipart uploads before deleting the bucket.
 	// S3 allows deleting buckets with pending multipart uploads, but our FK
-	// constraint requires them to be removed first.
-	uploads, _, _, _, listErr := h.MultipartUploads.ListByBucket(r.Context(), bucketName, "", "", "", 1000)
-	if listErr != nil {
-		h.logError("list multipart uploads for bucket deletion", listErr, bucketName, "", "")
-		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
-		return
-	}
-	for _, upload := range uploads {
-		if delErr := h.MultipartUploads.Delete(r.Context(), upload.ID); delErr != nil {
-			h.logError("delete multipart upload during bucket deletion", delErr, bucketName, upload.Key, upload.ID)
+	// constraint requires them to be removed first. Paginate through all
+	// uploads since there may be more than 1000.
+	const maxAbortIterations = 10 // safety ceiling (10K uploads at 1K/batch)
+	for range maxAbortIterations {
+		uploads, _, _, _, listErr := h.MultipartUploads.ListByBucket(r.Context(), bucketName, "", "", "", 1000)
+		if listErr != nil {
+			h.logError("list multipart uploads for bucket deletion", listErr, bucketName, "", "")
+			WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+			return
 		}
-		ctx, cancel := withCleanupTimeout()
-		if storErr := h.Storage.DeleteUploadParts(ctx, upload.ID); storErr != nil {
-			h.logError("delete upload parts during bucket deletion", storErr, bucketName, upload.Key, upload.ID)
+		if len(uploads) == 0 {
+			break
 		}
-		cancel()
+		for _, upload := range uploads {
+			if delErr := h.MultipartUploads.Delete(r.Context(), upload.ID); delErr != nil {
+				h.logError("delete multipart upload during bucket deletion", delErr, bucketName, upload.Key, upload.ID)
+			}
+			ctx, cancel := withCleanupTimeout()
+			if storErr := h.Storage.DeleteUploadParts(ctx, upload.ID); storErr != nil {
+				h.logError("delete upload parts during bucket deletion", storErr, bucketName, upload.Key, upload.ID)
+			}
+			cancel()
+		}
 	}
 
 	err = h.Buckets.Delete(r.Context(), bucketName)
@@ -72,7 +81,9 @@ func isSQLiteForeignKeyError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// SQLite: "FOREIGN KEY constraint failed" (and variants). Do not match
-	// other constraint types (e.g. UNIQUE) as BucketNotEmpty.
-	return strings.Contains(strings.ToLower(err.Error()), "foreign key")
+	var sqliteErr *sqlite.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code() == lib.SQLITE_CONSTRAINT_FOREIGNKEY
+	}
+	return false
 }

--- a/internal/s3/bucket_delete.go
+++ b/internal/s3/bucket_delete.go
@@ -26,6 +26,26 @@ func (h *ObjectHandlers) DeleteBucket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Abort any pending multipart uploads before deleting the bucket.
+	// S3 allows deleting buckets with pending multipart uploads, but our FK
+	// constraint requires them to be removed first.
+	uploads, _, _, _, listErr := h.MultipartUploads.ListByBucket(r.Context(), bucketName, "", "", "", 1000)
+	if listErr != nil {
+		h.logError("list multipart uploads for bucket deletion", listErr, bucketName, "", "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+	for _, upload := range uploads {
+		if delErr := h.MultipartUploads.Delete(r.Context(), upload.ID); delErr != nil {
+			h.logError("delete multipart upload during bucket deletion", delErr, bucketName, upload.Key, upload.ID)
+		}
+		ctx, cancel := withCleanupTimeout()
+		if storErr := h.Storage.DeleteUploadParts(ctx, upload.ID); storErr != nil {
+			h.logError("delete upload parts during bucket deletion", storErr, bucketName, upload.Key, upload.ID)
+		}
+		cancel()
+	}
+
 	err = h.Buckets.Delete(r.Context(), bucketName)
 	if errors.Is(err, metadata.ErrBucketNotFound) {
 		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchBucket, messageNoSuchBucket)

--- a/internal/s3/bucket_handlers.go
+++ b/internal/s3/bucket_handlers.go
@@ -82,6 +82,10 @@ func (h *ObjectHandlers) ListObjectsV2(w http.ResponseWriter, r *http.Request) {
 
 	bucketName := chiBucketParam(r)
 	params, err := parseListObjectsV2Params(r)
+	if errors.Is(err, errInvalidMaxKeys) {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+		return
+	}
 	if err != nil {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
 		return
@@ -109,7 +113,7 @@ func parseListObjectsV2Params(r *http.Request) (listObjectsV2Params, error) {
 	if rawMaxKeys := strings.TrimSpace(query.Get("max-keys")); rawMaxKeys != "" {
 		parsedMaxKeys, err := strconv.Atoi(rawMaxKeys)
 		if err != nil || parsedMaxKeys < 0 {
-			return listObjectsV2Params{}, errors.New("invalid max-keys")
+			return listObjectsV2Params{}, errInvalidMaxKeys
 		}
 		maxKeys = parsedMaxKeys
 	}

--- a/internal/s3/bucket_handlers_test.go
+++ b/internal/s3/bucket_handlers_test.go
@@ -348,7 +348,7 @@ func TestListObjectsV1InvalidMaxKeys(t *testing.T) {
 	if resp.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body=%s", resp.Code, resp.Body.String())
 	}
-	assertS3ErrorCode(t, resp.Body.Bytes(), codeInvalidRequest)
+	assertS3ErrorCode(t, resp.Body.Bytes(), codeInvalidArgument)
 }
 
 func TestListObjectsV2Prefix(t *testing.T) {
@@ -782,7 +782,6 @@ func TestNotImplementedSubresources(t *testing.T) {
 		method string
 		path   string
 	}{
-		{http.MethodGet, "/" + env.bucket + "?versions"},
 		{http.MethodGet, "/" + env.bucket + "?acl"},
 		{http.MethodPut, "/" + env.bucket + "?acl"},
 		{http.MethodGet, "/" + env.bucket + "/object.txt?acl"},
@@ -793,7 +792,6 @@ func TestNotImplementedSubresources(t *testing.T) {
 		{http.MethodGet, "/" + env.bucket + "?policy"},
 		{http.MethodPut, "/" + env.bucket + "?policy"},
 		{http.MethodDelete, "/" + env.bucket + "?policy"},
-		{http.MethodGet, "/" + env.bucket + "?uploads"},
 	}
 	for _, tc := range cases {
 		resp := env.do(t, tc.method, tc.path, "", nil)

--- a/internal/s3/checksum.go
+++ b/internal/s3/checksum.go
@@ -142,7 +142,7 @@ func addCRC64NVME(header http.Header, writers *[]io.Writer, checks *[]checksumCh
 	}
 	expected, err := decodeChecksum(value)
 	if err != nil || len(expected) != crc64.Size {
-		return fmt.Errorf("%s: %w", headerName, errInvalidDigest)
+		return fmt.Errorf("%s: %w", headerName, errInvalidChecksum)
 	}
 	h := crc64.New(crc64.MakeTable(crc64.ECMA))
 	*writers = append(*writers, h)

--- a/internal/s3/checksum.go
+++ b/internal/s3/checksum.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/crc32"
+	"hash/crc64"
 	"io"
 	"net/http"
 	"strings"
@@ -96,6 +97,9 @@ func newChecksumPipeline(header http.Header) (*checksumPipeline, error) {
 	if err := addCRC32Check(header, "x-amz-checksum-crc32c", crc32.MakeTable(crc32.Castagnoli), &writers, &checks); err != nil {
 		return nil, err
 	}
+	if err := addCRC64NVME(header, &writers, &checks); err != nil {
+		return nil, err
+	}
 
 	return &checksumPipeline{
 		md5Hash: md5Hash,
@@ -130,12 +134,44 @@ func addCRC32Check(header http.Header, headerName string, table *crc32.Table, wr
 	return nil
 }
 
+func addCRC64NVME(header http.Header, writers *[]io.Writer, checks *[]checksumCheck) error {
+	headerName := "x-amz-checksum-crc64nvme"
+	value := strings.TrimSpace(header.Get(headerName))
+	if value == "" {
+		return nil
+	}
+	expected, err := decodeChecksum(value)
+	if err != nil || len(expected) != crc64.Size {
+		return fmt.Errorf("%s: %w", headerName, errInvalidDigest)
+	}
+	h := crc64.New(crc64.MakeTable(crc64.ECMA))
+	*writers = append(*writers, h)
+	*checks = append(*checks, checksumCheck{
+		name:     headerName,
+		expected: expected,
+		sum: func() []byte {
+			return h.Sum(nil)
+		},
+	})
+	return nil
+}
+
 func (p *checksumPipeline) Reader(r io.Reader) io.Reader {
 	return io.TeeReader(r, p.writer)
 }
 
 func (p *checksumPipeline) ETag() string {
 	return hex.EncodeToString(p.md5Hash.Sum(nil))
+}
+
+// Checksums returns a map of all computed checksums keyed by header name.
+// Only includes checksums that were explicitly requested.
+func (p *checksumPipeline) Checksums() map[string]string {
+	cksum := make(map[string]string)
+	for _, c := range p.checks {
+		cksum[c.name] = base64.StdEncoding.EncodeToString(c.sum())
+	}
+	return cksum
 }
 
 func (p *checksumPipeline) Validate() error {

--- a/internal/s3/copy_object.go
+++ b/internal/s3/copy_object.go
@@ -92,16 +92,28 @@ func (h *ObjectHandlers) CopyObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := h.now()
+
+	// Determine metadata: COPY inherits from source, REPLACE parses from request.
+	var userMeta map[string]string
+	directive := strings.ToUpper(strings.TrimSpace(r.Header.Get("x-amz-metadata-directive")))
+	switch directive {
+	case "", "COPY":
+		userMeta = sourceObject.UserMetadata
+	case "REPLACE":
+		userMeta = parseMetadataHeaders(r)
+	}
+
 	destinationObject := &metadata.Object{
-		ID:          h.newID(),
-		BucketName:  destinationBucket,
-		Key:         destinationKey,
-		Size:        size,
-		ETag:        sourceObject.ETag,
-		ContentType: contentType,
-		StoragePath: storagePath,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:           h.newID(),
+		BucketName:   destinationBucket,
+		Key:          destinationKey,
+		Size:         size,
+		ETag:         sourceObject.ETag,
+		ContentType:  contentType,
+		StoragePath:  storagePath,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		UserMetadata: userMeta,
 	}
 	if err := h.Objects.Create(r.Context(), destinationObject); err != nil {
 		h.logError("create copied object metadata", err, destinationBucket, destinationKey, storagePath)

--- a/internal/s3/dispatch.go
+++ b/internal/s3/dispatch.go
@@ -5,8 +5,12 @@ import "net/http"
 func (h *ObjectHandlers) DispatchBucketGet(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	switch {
-	case query.Has("versions"), query.Has("acl"), query.Has("cors"), query.Has("policy"), query.Has("uploads"), query.Has("uploadId"):
+	case query.Has("acl"), query.Has("cors"), query.Has("policy"):
 		h.NotImplemented(w, r)
+	case query.Has("versions"):
+		h.ListObjectVersions(w, r)
+	case query.Has("uploads"):
+		h.ListMultipartUploads(w, r)
 	case query.Has("location"):
 		h.GetBucketLocation(w, r)
 	case query.Get("list-type") == "2":
@@ -55,7 +59,15 @@ func (h *ObjectHandlers) DispatchBucketDelete(w http.ResponseWriter, r *http.Req
 
 func (h *ObjectHandlers) DispatchObjectGet(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
-	if query.Has("acl") || query.Has("uploadId") || query.Has("uploads") {
+	if query.Has("uploadId") {
+		h.ListParts(w, r)
+		return
+	}
+	if query.Has("attributes") {
+		h.GetObjectAttributes(w, r)
+		return
+	}
+	if query.Has("acl") || query.Has("uploads") {
 		h.NotImplemented(w, r)
 		return
 	}

--- a/internal/s3/errors.go
+++ b/internal/s3/errors.go
@@ -1,5 +1,7 @@
 package s3
 
+import "errors"
+
 const (
 	codeBucketAlreadyExists       = "BucketAlreadyExists"
 	codeBucketAlreadyOwnedByYou   = "BucketAlreadyOwnedByYou"
@@ -8,18 +10,23 @@ const (
 	codeBadDigest                 = "BadDigest"
 	codeEntityTooSmall            = "EntityTooSmall"
 	codeInternalError             = "InternalError"
+	codeInvalidArgument           = "InvalidArgument"
 	codeInvalidBucketName         = "InvalidBucketName"
 	codeInvalidDigest             = "InvalidDigest"
 	codeInvalidLocationConstraint = "InvalidLocationConstraint"
 	codeInvalidPart               = "InvalidPart"
 	codeInvalidPartOrder          = "InvalidPartOrder"
+	codeInvalidRange              = "InvalidRange"
 	codeInvalidRequest            = "InvalidRequest"
 	codeMalformedXML              = "MalformedXML"
 	codeNoSuchBucket              = "NoSuchBucket"
 	codeNoSuchKey                 = "NoSuchKey"
-	codeNotImplemented            = "NotImplemented"
 	codeNoSuchUpload              = "NoSuchUpload"
+	codeNotImplemented            = "NotImplemented"
+	codePreconditionFailed        = "PreconditionFailed"
 )
+
+var errRangeExceedsSize = errors.New("range exceeds object size")
 
 const (
 	messageBucketAlreadyExists       = "The requested bucket name is not available."
@@ -29,6 +36,7 @@ const (
 	messageBadDigest                 = "The Content-MD5 or checksum you specified did not match what we received."
 	messageEntityTooSmall            = "Your proposed upload is smaller than the minimum allowed object size."
 	messageInternalError             = "We encountered an internal error. Please try again."
+	messageInvalidArgument           = "Invalid argument."
 	messageInvalidBucketName         = "The specified bucket is not valid."
 	messageInvalidDigest             = "The Content-MD5 you specified was invalid."
 	messageInvalidLocationConstraint = "The specified location-constraint is not valid."
@@ -40,4 +48,7 @@ const (
 	messageNoSuchKey                 = "The specified key does not exist."
 	messageNotImplemented            = "A header or query you provided implies functionality that is not implemented."
 	messageNoSuchUpload              = "The specified multipart upload does not exist."
+	messagePreconditionFailed        = "At least one of the pre-conditions you specified did not hold."
 )
+
+var errInvalidMaxKeys = errors.New("invalid max-keys")

--- a/internal/s3/list_object_versions.go
+++ b/internal/s3/list_object_versions.go
@@ -19,11 +19,14 @@ func (h *ObjectHandlers) ListObjectVersions(w http.ResponseWriter, r *http.Reque
 
 	maxKeys := 1000
 	if v := r.URL.Query().Get("max-keys"); v != "" {
-		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
-			maxKeys = parsed
-			if maxKeys > 1000 {
-				maxKeys = 1000
-			}
+		parsed, err := strconv.Atoi(v)
+		if err != nil || parsed <= 0 {
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+			return
+		}
+		maxKeys = parsed
+		if maxKeys > 1000 {
+			maxKeys = 1000
 		}
 	}
 
@@ -42,8 +45,8 @@ func (h *ObjectHandlers) ListObjectVersions(w http.ResponseWriter, r *http.Reque
 			Key:          obj.Key,
 			VersionID:    "null",
 			IsLatest:     true,
-			LastModified: obj.CreatedAt.Format(time.RFC3339),
-			ETag:         obj.ETag,
+			LastModified: obj.UpdatedAt.Format(time.RFC3339),
+			ETag:         quoteETag(obj.ETag),
 			Size:         obj.Size,
 			StorageClass: "STANDARD",
 		})

--- a/internal/s3/list_object_versions.go
+++ b/internal/s3/list_object_versions.go
@@ -1,0 +1,69 @@
+package s3
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/i-got-this-faa/fbs/internal/authz"
+)
+
+// ListObjectVersions returns current objects as versions (versioning not supported).
+func (h *ObjectHandlers) ListObjectVersions(w http.ResponseWriter, r *http.Request) {
+	bucketName := chiBucketParam(r)
+	prefix := r.URL.Query().Get("prefix")
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", prefix) {
+		return
+	}
+
+	maxKeys := 1000
+	if v := r.URL.Query().Get("max-keys"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			maxKeys = parsed
+			if maxKeys > 1000 {
+				maxKeys = 1000
+			}
+		}
+	}
+
+	keyMarker := r.URL.Query().Get("key-marker")
+
+	objects, isTruncated, err := h.Objects.List(r.Context(), bucketName, prefix, keyMarker, maxKeys)
+	if err != nil {
+		h.logError("list objects for versions", err, bucketName, "", "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+
+	versions := make([]ListVersionsEntry, 0, len(objects))
+	for _, obj := range objects {
+		versions = append(versions, ListVersionsEntry{
+			Key:          obj.Key,
+			VersionID:    "null",
+			IsLatest:     true,
+			LastModified: obj.CreatedAt.Format(time.RFC3339),
+			ETag:         obj.ETag,
+			Size:         obj.Size,
+			StorageClass: "STANDARD",
+		})
+	}
+
+	nextKeyMarker := ""
+	if isTruncated && len(objects) > 0 {
+		nextKeyMarker = objects[len(objects)-1].Key
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(ListVersionsResult{
+		Xmlns:         "http://s3.amazonaws.com/doc/2006-03-01/",
+		Name:          bucketName,
+		Prefix:        prefix,
+		KeyMarker:     keyMarker,
+		NextKeyMarker: nextKeyMarker,
+		MaxKeys:       maxKeys,
+		IsTruncated:   isTruncated,
+		Version:       versions,
+	})
+}

--- a/internal/s3/list_objects_v1.go
+++ b/internal/s3/list_objects_v1.go
@@ -36,6 +36,10 @@ type listObjectsV1Params struct {
 func (h *ObjectHandlers) ListObjectsV1(w http.ResponseWriter, r *http.Request) {
 	bucketName := chiBucketParam(r)
 	params, err := parseListObjectsV1Params(r)
+	if errors.Is(err, errInvalidMaxKeys) {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+		return
+	}
 	if err != nil {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
 		return
@@ -63,7 +67,7 @@ func parseListObjectsV1Params(r *http.Request) (listObjectsV1Params, error) {
 	if rawMaxKeys := strings.TrimSpace(query.Get("max-keys")); rawMaxKeys != "" {
 		parsedMaxKeys, err := strconv.Atoi(rawMaxKeys)
 		if err != nil || parsedMaxKeys < 0 {
-			return listObjectsV1Params{}, errors.New("invalid max-keys")
+			return listObjectsV1Params{}, errInvalidMaxKeys
 		}
 		maxKeys = parsedMaxKeys
 	}

--- a/internal/s3/multipart_handlers.go
+++ b/internal/s3/multipart_handlers.go
@@ -360,17 +360,14 @@ func (h *ObjectHandlers) ListParts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter parts by marker.
-	found := false
+	startIdx := len(parts)
 	for i, p := range parts {
 		if p.PartNumber > partNumberMarker {
-			parts = parts[i:]
-			found = true
+			startIdx = i
 			break
 		}
 	}
-	if !found {
-		parts = nil
-	}
+	parts = parts[startIdx:]
 
 	isTruncated := len(parts) > maxParts
 	if isTruncated {
@@ -964,8 +961,9 @@ func (h *ObjectHandlers) UploadPartCopy(w http.ResponseWriter, r *http.Request) 
 	})
 }
 
-// parseByteRange parses an x-amz-copy-source-range value in the format "bytes=start-end"
-// and clamps to the object size.
+// parseByteRange parses an x-amz-copy-source-range value in the format "bytes=start-end".
+// Returns a parse error (leading to a 416/400 response) for out-of-range values,
+// not a clamped range.
 func parseByteRange(rangeHeader string, objectSize int64) (start, end int64, err error) {
 	const prefix = "bytes="
 	if !strings.HasPrefix(rangeHeader, prefix) {

--- a/internal/s3/multipart_handlers.go
+++ b/internal/s3/multipart_handlers.go
@@ -360,15 +360,16 @@ func (h *ObjectHandlers) ListParts(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter parts by marker.
-	startIdx := 0
+	found := false
 	for i, p := range parts {
 		if p.PartNumber > partNumberMarker {
-			startIdx = i
+			parts = parts[i:]
+			found = true
 			break
 		}
 	}
-	if startIdx > 0 {
-		parts = parts[startIdx:]
+	if !found {
+		parts = nil
 	}
 
 	isTruncated := len(parts) > maxParts

--- a/internal/s3/multipart_handlers.go
+++ b/internal/s3/multipart_handlers.go
@@ -2,9 +2,12 @@ package s3
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -32,19 +35,30 @@ func (h *ObjectHandlers) CreateMultipartUpload(w http.ResponseWriter, r *http.Re
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
 		return
 	}
-
 	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
 
+	// Read the x-amz-checksum-algorithm header if provided.
+	checksumAlgo := strings.TrimSpace(r.Header.Get("x-amz-checksum-algorithm"))
+	switch checksumAlgo {
+	case "SHA256", "SHA1", "CRC32", "CRC32C", "CRC64NVME", "":
+		// valid values
+	default:
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+		return
+	}
+
 	upload := &metadata.MultipartUpload{
-		ID:          h.newID(),
-		BucketName:  bucketName,
-		Key:         key,
-		ContentType: contentType,
-		Status:      metadata.MultipartUploadStatusActive,
-		CreatedAt:   h.now(),
+		ID:                h.newID(),
+		BucketName:        bucketName,
+		Key:               key,
+		ContentType:       contentType,
+		ChecksumAlgorithm: checksumAlgo,
+		Status:            metadata.MultipartUploadStatusActive,
+		CreatedAt:         h.now(),
+		UserMetadata:      parseMetadataHeaders(r),
 	}
 	if err := h.MultipartUploads.Create(r.Context(), upload); err != nil {
 		h.logError("create multipart upload", err, bucketName, key, "")
@@ -53,11 +67,83 @@ func (h *ObjectHandlers) CreateMultipartUpload(w http.ResponseWriter, r *http.Re
 	}
 
 	w.Header().Set("Content-Type", "application/xml")
+	if checksumAlgo != "" {
+		w.Header().Set("x-amz-checksum-algorithm", checksumAlgo)
+	}
 	w.WriteHeader(http.StatusOK)
 	_ = xml.NewEncoder(w).Encode(InitiateMultipartUploadResult{
-		Bucket:   bucketName,
-		Key:      key,
-		UploadID: upload.ID,
+		Bucket:            bucketName,
+		Key:               key,
+		UploadID:          upload.ID,
+		ChecksumAlgorithm: checksumAlgo,
+		Xmlns:             "http://s3.amazonaws.com/doc/2006-03-01/",
+	})
+}
+
+// ListMultipartUploads handles GET /{bucket}?uploads.
+func (h *ObjectHandlers) ListMultipartUploads(w http.ResponseWriter, r *http.Request) {
+	bucketName := chiBucketParam(r)
+	prefix := r.URL.Query().Get("prefix")
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionListBucket, "", prefix) {
+		return
+	}
+
+	q := r.URL.Query()
+	maxUploads := 1000
+	if raw := strings.TrimSpace(q.Get("max-uploads")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+			return
+		}
+		if parsed > 0 {
+			maxUploads = parsed
+		}
+	}
+	if maxUploads > 1000 {
+		maxUploads = 1000
+	}
+
+	prefix = q.Get("prefix")
+	keyMarker := q.Get("key-marker")
+	uploadIDMarker := q.Get("upload-id-marker")
+	delimiter := q.Get("delimiter")
+
+	uploads, isTruncated, nextKeyMarker, nextUploadIDMarker, err := h.MultipartUploads.ListByBucket(
+		r.Context(), bucketName, prefix, keyMarker, uploadIDMarker, maxUploads,
+	)
+	if err != nil {
+		h.logError("list multipart uploads", err, bucketName, "", "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+
+	entries := make([]MultipartUploadEntry, 0, len(uploads))
+	for _, u := range uploads {
+		entries = append(entries, MultipartUploadEntry{
+			Key:          u.Key,
+			UploadID:     u.ID,
+			Initiator:    Owner{ID: "anonymous", DisplayName: "anonymous"},
+			Owner:        Owner{ID: "anonymous", DisplayName: "anonymous"},
+			StorageClass: "STANDARD",
+			Initiated:    u.CreatedAt.Format(time.RFC3339),
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(ListMultipartUploadsResult{
+		Xmlns:              "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:             bucketName,
+		KeyMarker:          keyMarker,
+		UploadIDMarker:     uploadIDMarker,
+		NextKeyMarker:      nextKeyMarker,
+		NextUploadIDMarker: nextUploadIDMarker,
+		MaxUploads:         maxUploads,
+		IsTruncated:        isTruncated,
+		Upload:             entries,
+		Prefix:             prefix,
+		Delimiter:          delimiter,
 	})
 }
 
@@ -98,6 +184,12 @@ func (h *ObjectHandlers) UploadPart(w http.ResponseWriter, r *http.Request) {
 	}
 	if upload.BucketName != bucketName || upload.Key != key {
 		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	}
+
+	// Check conditional headers (If-Match / If-None-Match) against the existing object.
+	existingObj, _ := h.Objects.GetByKey(r.Context(), bucketName, key)
+	if h.checkPreconditionFailed(w, r, existingObj) {
 		return
 	}
 
@@ -147,13 +239,19 @@ func (h *ObjectHandlers) UploadPart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cksums := pipeline.Checksums()
 	part := &metadata.MultipartPart{
-		UploadID:    uploadID,
-		PartNumber:  partNumber,
-		Size:        size,
-		ETag:        pipeline.ETag(),
-		StoragePath: storagePath,
-		CreatedAt:   h.now(),
+		UploadID:         uploadID,
+		PartNumber:       partNumber,
+		Size:             size,
+		ETag:             pipeline.ETag(),
+		StoragePath:      storagePath,
+		CreatedAt:        h.now(),
+		ChecksumCRC32:    cksums["x-amz-checksum-crc32"],
+		ChecksumCRC32C:   cksums["x-amz-checksum-crc32c"],
+		ChecksumCRC64NVME: cksums["x-amz-checksum-crc64nvme"],
+		ChecksumSHA1:     cksums["x-amz-checksum-sha1"],
+		ChecksumSHA256:   cksums["x-amz-checksum-sha256"],
 	}
 	oldStoragePath, err := h.MultipartUploads.AddPart(r.Context(), part)
 	if err != nil {
@@ -179,11 +277,26 @@ func (h *ObjectHandlers) UploadPart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("ETag", quoteETag(part.ETag))
+	if cksums["x-amz-checksum-crc32"] != "" {
+		w.Header().Set("x-amz-checksum-crc32", cksums["x-amz-checksum-crc32"])
+	}
+	if cksums["x-amz-checksum-crc32c"] != "" {
+		w.Header().Set("x-amz-checksum-crc32c", cksums["x-amz-checksum-crc32c"])
+	}
+	if cksums["x-amz-checksum-crc64nvme"] != "" {
+		w.Header().Set("x-amz-checksum-crc64nvme", cksums["x-amz-checksum-crc64nvme"])
+	}
+	if cksums["x-amz-checksum-sha1"] != "" {
+		w.Header().Set("x-amz-checksum-sha1", cksums["x-amz-checksum-sha1"])
+	}
+	if cksums["x-amz-checksum-sha256"] != "" {
+		w.Header().Set("x-amz-checksum-sha256", cksums["x-amz-checksum-sha256"])
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
-// CompleteMultipartUpload handles POST /{bucket}/{key}?uploadId={id}.
-func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
+// ListParts handles GET /{bucket}/{key}?uploadId={id}.
+func (h *ObjectHandlers) ListParts(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
 	if key == "" {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
@@ -204,6 +317,133 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
 		return
 	} else if err != nil {
+		h.logError("get multipart upload for list parts", err, bucketName, key, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+	if upload.BucketName != bucketName || upload.Key != key {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	}
+
+	parts, err := h.MultipartUploads.ListParts(r.Context(), uploadID)
+	if err != nil {
+		h.logError("list parts", err, bucketName, key, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+
+	q := r.URL.Query()
+	maxParts := 1000
+	if raw := strings.TrimSpace(q.Get("max-parts")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+			return
+		}
+		if parsed > 0 {
+			maxParts = parsed
+		}
+	}
+	if maxParts > 1000 {
+		maxParts = 1000
+	}
+
+	partNumberMarker := 0
+	if raw := strings.TrimSpace(q.Get("part-number-marker")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 0 {
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+			return
+		}
+		partNumberMarker = parsed
+	}
+
+	// Filter parts by marker.
+	startIdx := 0
+	for i, p := range parts {
+		if p.PartNumber > partNumberMarker {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx > 0 {
+		parts = parts[startIdx:]
+	}
+
+	isTruncated := len(parts) > maxParts
+	if isTruncated {
+		parts = parts[:maxParts]
+	}
+
+	partEntries := make([]ListPartsPart, 0, len(parts))
+	for _, p := range parts {
+		partEntries = append(partEntries, ListPartsPart{
+			PartNumber:   p.PartNumber,
+			LastModified: p.CreatedAt.Format(time.RFC3339),
+			ETag:         quoteETag(p.ETag),
+			Size:         p.Size,
+		})
+	}
+
+	nextMarker := 0
+	if isTruncated && len(parts) > 0 {
+		nextMarker = parts[len(parts)-1].PartNumber
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(ListPartsResult{
+		Xmlns:                "http://s3.amazonaws.com/doc/2006-03-01/",
+		Bucket:               bucketName,
+		Key:                  key,
+		UploadID:             uploadID,
+		Initiator:            Owner{ID: "anonymous", DisplayName: "anonymous"},
+		Owner:                Owner{ID: "anonymous", DisplayName: "anonymous"},
+		StorageClass:         "STANDARD",
+		PartNumberMarker:     partNumberMarker,
+		NextPartNumberMarker: nextMarker,
+		MaxParts:             maxParts,
+		IsTruncated:          isTruncated,
+		Part:                 partEntries,
+	})
+}
+
+// CompleteMultipartUpload handles POST /{bucket}/{key}?uploadId={id}.
+func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.Request) {
+	bucketName, key := objectRouteParams(r)
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
+		return
+	}
+	if key == "" {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+
+	uploadID := r.URL.Query().Get("uploadId")
+	if uploadID == "" {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	upload, err := h.MultipartUploads.GetByID(r.Context(), uploadID)
+	if errors.Is(err, metadata.ErrMultipartUploadNotFound) {
+		// S3 idempotency: if the upload is gone but the object exists,
+		// the upload was already completed — return success as S3 does.
+		if existing, getErr := h.Objects.GetByKey(r.Context(), bucketName, key); getErr == nil && existing != nil {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusOK)
+			_ = xml.NewEncoder(w).Encode(CompleteMultipartUploadResult{
+				Location: fmt.Sprintf("/%s/%s", bucketName, key),
+				Bucket:   bucketName,
+				Key:      key,
+				ETag:     quoteETag(existing.ETag),
+				Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+			})
+			return
+		}
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	} else if err != nil {
 		h.logError("get multipart upload", err, bucketName, key, "")
 		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
 		return
@@ -213,12 +453,37 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Check conditional headers (If-Match / If-None-Match) against the existing object.
+	existingObj, _ := h.Objects.GetByKey(r.Context(), bucketName, key)
+	if h.checkPreconditionFailed(w, r, existingObj) {
+		return
+	}
+	// S3 returns NoSuchKey when If-Match is set and the object does not exist.
+	if existingObj == nil && r.Header.Get("If-Match") != "" {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchKey, messageNoSuchKey)
+		return
+	}
+
 	release := h.acquireUploadLock(uploadID)
 	defer release()
 
 	// Re-read upload after locking to detect races with abort/complete.
 	upload, err = h.MultipartUploads.GetByID(r.Context(), uploadID)
 	if errors.Is(err, metadata.ErrMultipartUploadNotFound) {
+		// Same idempotency check after lock acquisition — the upload may have
+		// been completed by another process while we were waiting for the lock.
+		if existing, getErr := h.Objects.GetByKey(r.Context(), bucketName, key); getErr == nil && existing != nil {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusOK)
+			_ = xml.NewEncoder(w).Encode(CompleteMultipartUploadResult{
+				Location: fmt.Sprintf("/%s/%s", bucketName, key),
+				Bucket:   bucketName,
+				Key:      key,
+				ETag:     quoteETag(existing.ETag),
+				Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
+			})
+			return
+		}
 		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
 		return
 	} else if err != nil {
@@ -230,6 +495,7 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
 		return
 	}
+
 
 	claimed := false
 	completed := false
@@ -266,9 +532,23 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Verify ascending order and no duplicates.
+	// Deduplicate part numbers: S3 uses the last occurrence for each part number.
+	seen := make(map[int]int, len(req.Parts))
+	uniqueParts := make([]CompletePart, 0, len(req.Parts))
+	for _, p := range req.Parts {
+		if idx, ok := seen[p.PartNumber]; ok {
+			uniqueParts[idx] = p
+		} else {
+			seen[p.PartNumber] = len(uniqueParts)
+			uniqueParts = append(uniqueParts, p)
+		}
+	}
+	req.Parts = uniqueParts
+
+	// Verify non-decreasing order (duplicates already deduplicated, so this
+	// effectively checks strictly ascending with tolerance for dedup).
 	for i := 1; i < len(req.Parts); i++ {
-		if req.Parts[i].PartNumber <= req.Parts[i-1].PartNumber {
+		if req.Parts[i].PartNumber < req.Parts[i-1].PartNumber {
 			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidPartOrder, messageInvalidPartOrder)
 			return
 		}
@@ -334,15 +614,18 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 	}
 
 	obj := &metadata.Object{
-		ID:          h.newID(),
-		BucketName:  bucketName,
-		Key:         key,
-		Size:        size,
-		ETag:        etag,
-		ContentType: contentType,
-		StoragePath: storagePath,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:           h.newID(),
+		BucketName:   bucketName,
+		Key:          key,
+		Size:         size,
+		ETag:         etag,
+		ContentType:  contentType,
+		StoragePath:  storagePath,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		IsMultipart:  true,
+		PartsCount:   len(req.Parts),
+		UserMetadata: upload.UserMetadata,
 	}
 
 	// CompleteUpload atomically verifies the upload still exists, creates the
@@ -401,6 +684,7 @@ func (h *ObjectHandlers) CompleteMultipartUpload(w http.ResponseWriter, r *http.
 		Bucket:   bucketName,
 		Key:      key,
 		ETag:     quoteETag(etag),
+		Xmlns:    "http://s3.amazonaws.com/doc/2006-03-01/",
 	})
 }
 
@@ -491,8 +775,224 @@ func (h *ObjectHandlers) AbortMultipartUpload(w http.ResponseWriter, r *http.Req
 		h.logError("delete upload parts", err, bucketName, key, "")
 	}
 	cancel()
-
 	w.WriteHeader(http.StatusNoContent)
+}
+
+
+// UploadPartCopy handles PUT /{bucket}/{key}?partNumber={n}&uploadId={id} with x-amz-copy-source.
+func (h *ObjectHandlers) UploadPartCopy(w http.ResponseWriter, r *http.Request) {
+	bucketName, key := objectRouteParams(r)
+	if !h.ensureBucketAction(w, r, bucketName, authz.ActionPutObject, key, "") {
+		return
+	}
+	if key == "" {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+
+	q := r.URL.Query()
+	uploadID := q.Get("uploadId")
+	partNumberStr := q.Get("partNumber")
+
+	if uploadID == "" || partNumberStr == "" {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+
+	partNumber, err := strconv.Atoi(partNumberStr)
+	if err != nil || partNumber < 1 || partNumber > 10000 {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+
+	copySource := r.Header.Get("x-amz-copy-source")
+	if copySource == "" {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+
+	source, err := parseCopySource(copySource)
+	if err != nil {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if source.versionID != "" {
+		WriteS3Error(w, r, http.StatusNotImplemented, codeNotImplemented, messageNotImplemented)
+		return
+	}
+
+	// Validate the multipart upload exists and matches the target key.
+	upload, err := h.MultipartUploads.GetByID(r.Context(), uploadID)
+	if errors.Is(err, metadata.ErrMultipartUploadNotFound) {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	} else if err != nil {
+		h.logError("get multipart upload for copy part", err, bucketName, key, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+	if upload.BucketName != bucketName || upload.Key != key {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	}
+
+	// Ensure the source bucket exists.
+	if !h.ensureBucketAction(w, r, source.bucketName, authz.ActionGetObject, source.key, "") {
+		return
+	}
+
+	// Load source object.
+	sourceObject, err := h.Objects.GetByKey(r.Context(), source.bucketName, source.key)
+	if errors.Is(err, metadata.ErrObjectNotFound) {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchKey, messageNoSuchKey)
+		return
+	} else if err != nil {
+		h.logError("get source object for copy part", err, source.bucketName, source.key, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+
+	// Open source file.
+	sourceFile, err := h.Storage.Open(r.Context(), sourceObject.StoragePath)
+	if err != nil {
+		h.logError("open source object for copy part", err, source.bucketName, source.key, sourceObject.StoragePath)
+		if errors.Is(err, storage.ErrNotFound) {
+			WriteS3Error(w, r, http.StatusNotFound, codeNoSuchKey, messageNoSuchKey)
+			return
+		}
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+	defer sourceFile.Close()
+
+	var srcReader io.Reader = sourceFile
+	srcSize := sourceObject.Size
+
+	// Handle optional x-amz-copy-source-range.
+	if rangeHeader := r.Header.Get("x-amz-copy-source-range"); rangeHeader != "" {
+		start, end, err := parseByteRange(rangeHeader, srcSize)
+		if err != nil {
+			if errors.Is(err, errRangeExceedsSize) {
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", srcSize))
+				WriteS3Error(w, r, http.StatusRequestedRangeNotSatisfiable, codeInvalidRange, "The requested range is not valid.")
+				return
+			}
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+			return
+		}
+		if _, err := sourceFile.Seek(start, io.SeekStart); err != nil {
+			h.logError("seek source file for copy part range", err, source.bucketName, source.key, sourceObject.StoragePath)
+			WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+			return
+		}
+		srcReader = io.LimitReader(sourceFile, end-start+1)
+		srcSize = end - start + 1
+	}
+
+	// Acquire upload lock.
+	release := h.acquireUploadLock(uploadID)
+	defer release()
+
+	// Re-read upload after locking.
+	upload, err = h.MultipartUploads.GetByID(r.Context(), uploadID)
+	if errors.Is(err, metadata.ErrMultipartUploadNotFound) {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	} else if err != nil {
+		h.logError("re-read multipart upload after lock", err, bucketName, key, "")
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+	if upload.BucketName != bucketName || upload.Key != key {
+		WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+		return
+	}
+
+	// Compute the ETag directly from the copy source data.
+	// UploadPartCopy has no request body, so Content-MD5/payload checksum
+	// headers from the SDK (computed against the empty body) must not be
+	// validated against the source data — skip checksum pipeline entirely.
+	md5Hash := md5.New()
+	copyReader := io.TeeReader(srcReader, md5Hash)
+
+	storagePath, size, err := h.Storage.WritePart(r.Context(), uploadID, partNumber, copyReader)
+	if err != nil {
+		h.writeStorageMutationError(w, r, err, bucketName, key, "")
+		return
+	}
+
+	etag := hex.EncodeToString(md5Hash.Sum(nil))
+
+	part := &metadata.MultipartPart{
+		UploadID:    uploadID,
+		PartNumber:  partNumber,
+		Size:        size,
+		ETag:        etag,
+		StoragePath: storagePath,
+		CreatedAt:   h.now(),
+	}
+
+	oldStoragePath, err := h.MultipartUploads.AddPart(r.Context(), part)
+	if err != nil {
+		ctx, cancel := withCleanupTimeout()
+		_ = h.Storage.Delete(ctx, storagePath)
+		cancel()
+		if errors.Is(err, metadata.ErrUploadAlreadyClaimed) || errors.Is(err, metadata.ErrMultipartUploadNotFound) {
+			WriteS3Error(w, r, http.StatusNotFound, codeNoSuchUpload, messageNoSuchUpload)
+			return
+		}
+		h.logError("add multipart part metadata", err, bucketName, key, storagePath)
+		WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+		return
+	}
+
+	if oldStoragePath != "" && oldStoragePath != storagePath {
+		ctx, cancel := withCleanupTimeout()
+		err := h.Storage.Delete(ctx, oldStoragePath)
+		cancel()
+		if err != nil {
+			h.logError("delete old part file after re-upload", err, bucketName, key, oldStoragePath)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(CopyPartResult{
+		LastModified: part.CreatedAt.Format(time.RFC3339),
+		ETag:         quoteETag(part.ETag),
+	})
+}
+
+// parseByteRange parses an x-amz-copy-source-range value in the format "bytes=start-end"
+// and clamps to the object size.
+func parseByteRange(rangeHeader string, objectSize int64) (start, end int64, err error) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(rangeHeader, prefix) {
+		return 0, 0, fmt.Errorf("invalid byte range format")
+	}
+	rangeVal := strings.TrimSpace(rangeHeader[len(prefix):])
+	parts := strings.SplitN(rangeVal, "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid byte range format")
+	}
+	start, err = strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil || start < 0 {
+		return 0, 0, fmt.Errorf("invalid byte range start")
+	}
+	end, err = strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+	if err != nil || end < 0 {
+		return 0, 0, fmt.Errorf("invalid byte range end")
+	}
+	if start > end {
+		return 0, 0, fmt.Errorf("invalid byte range")
+	}
+	if start >= objectSize {
+		return 0, 0, fmt.Errorf("range start exceeds object size")
+	}
+	if end >= objectSize {
+		return start, end, fmt.Errorf("%w: range end %d >= object size %d", errRangeExceedsSize, end, objectSize)
+	}
+	return start, end, nil
 }
 
 // DispatchPut routes PUT requests to either PutObject or UploadPart.
@@ -501,11 +1001,19 @@ func (h *ObjectHandlers) DispatchPut(w http.ResponseWriter, r *http.Request) {
 	hasUploadID := q.Has("uploadId")
 	hasPartNumber := q.Has("partNumber")
 	if hasUploadID && hasPartNumber && q.Get("uploadId") != "" && q.Get("partNumber") != "" {
+		if r.Header.Get("x-amz-copy-source") != "" {
+			h.UploadPartCopy(w, r)
+			return
+		}
 		h.UploadPart(w, r)
 		return
 	}
 	if hasUploadID || hasPartNumber {
 		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidRequest, messageInvalidRequest)
+		return
+	}
+	if r.Header.Get("x-amz-copy-source") != "" {
+		h.CopyObject(w, r)
 		return
 	}
 	h.PutObject(w, r)

--- a/internal/s3/multipart_handlers.go
+++ b/internal/s3/multipart_handlers.go
@@ -359,15 +359,20 @@ func (h *ObjectHandlers) ListParts(w http.ResponseWriter, r *http.Request) {
 		partNumberMarker = parsed
 	}
 
-	// Filter parts by marker.
-	startIdx := len(parts)
+	// Filter parts by marker: return only parts with PartNumber > marker.
+	// If no part exceeds the marker, return an empty result.
+	startIdx := -1
 	for i, p := range parts {
 		if p.PartNumber > partNumberMarker {
 			startIdx = i
 			break
 		}
 	}
-	parts = parts[startIdx:]
+	if startIdx == -1 {
+		parts = nil
+	} else {
+		parts = parts[startIdx:]
+	}
 
 	isTruncated := len(parts) > maxParts
 	if isTruncated {

--- a/internal/s3/multipart_handlers_test.go
+++ b/internal/s3/multipart_handlers_test.go
@@ -612,12 +612,13 @@ func TestCompleteMultipartUploadValidationFailureResetsClaim(t *testing.T) {
 	uploadID := env.mustCreateMultipartUpload(t, "large.zip")
 
 	etag := env.mustUploadPart(t, uploadID, "large.zip", 1, "part one")
+	etag2 := env.mustUploadPart(t, uploadID, "large.zip", 2, "part two")
 
-	// Send an invalid complete request (parts out of order).
+	// Send an invalid complete request (parts out of order: 2 then 1).
 	completeXML := fmt.Sprintf(`<CompleteMultipartUpload>
+		<Part><PartNumber>2</PartNumber><ETag>%s</ETag></Part>
 		<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
-		<Part><PartNumber>1</PartNumber><ETag>%s</ETag></Part>
-	</CompleteMultipartUpload>`, etag, etag)
+	</CompleteMultipartUpload>`, etag2, etag)
 
 	resp := env.do(t, http.MethodPost, fmt.Sprintf("/%s/large.zip?uploadId=%s", env.bucket, uploadID), completeXML, nil)
 	if resp.Code != http.StatusBadRequest {

--- a/internal/s3/object_handlers.go
+++ b/internal/s3/object_handlers.go
@@ -231,10 +231,12 @@ func (h *ObjectHandlers) handlePartNumber(w http.ResponseWriter, r *http.Request
 		return true
 	}
 
-	// For multipart objects, serve the full object with part metadata headers.
-	// Full per-part range serving requires storing per-part sizes in object metadata.
+	// Per-part range serving is not yet implemented; returning the full object
+	// with a wrong Content-Length would silently corrupt parallel downloads.
+	// Return 501 until per-part storage metadata is available.
 	w.Header().Set("x-amz-mp-parts-count", strconv.Itoa(obj.PartsCount))
-	return false
+	WriteS3Error(w, r, http.StatusNotImplemented, codeNotImplemented, messageNotImplemented)
+	return true
 }
 func (h *ObjectHandlers) GetObjectAttributes(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
@@ -274,6 +276,7 @@ func (h *ObjectHandlers) GetObjectAttributes(w http.ResponseWriter, r *http.Requ
 	}
 
 	result := GetObjectAttributesResult{
+		Xmlns:        "http://s3.amazonaws.com/doc/2006-03-01/",
 		LastModified: obj.UpdatedAt.Format(time.RFC3339),
 		ObjectSize:   obj.Size,
 	}

--- a/internal/s3/object_handlers.go
+++ b/internal/s3/object_handlers.go
@@ -136,18 +136,23 @@ func (h *ObjectHandlers) PutObject(w http.ResponseWriter, r *http.Request) {
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
-
+	cs := pipeline.Checksums()
 	obj := &metadata.Object{
-		ID:           h.newID(),
-		BucketName:   bucketName,
-		Key:          key,
-		Size:         size,
-		ETag:         pipeline.ETag(),
-		ContentType:  contentType,
-		StoragePath:  storagePath,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-		UserMetadata: parseMetadataHeaders(r),
+		ID:                h.newID(),
+		BucketName:        bucketName,
+		Key:               key,
+		Size:              size,
+		ETag:              pipeline.ETag(),
+		ContentType:       contentType,
+		StoragePath:       storagePath,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		UserMetadata:      parseMetadataHeaders(r),
+		ChecksumCRC32:     cs["x-amz-checksum-crc32"],
+		ChecksumCRC32C:    cs["x-amz-checksum-crc32c"],
+		ChecksumCRC64NVME: cs["x-amz-checksum-crc64nvme"],
+		ChecksumSHA1:      cs["x-amz-checksum-sha1"],
+		ChecksumSHA256:    cs["x-amz-checksum-sha256"],
 	}
 
 	if err := h.Objects.Create(r.Context(), obj); err != nil {
@@ -217,7 +222,7 @@ func (h *ObjectHandlers) handlePartNumber(w http.ResponseWriter, r *http.Request
 			return true
 		}
 		// PartNumber=1 on a non-multipart object returns the full object.
-		w.Header().Set("x-amz-mp-parts-count", "1")
+		// x-amz-mp-parts-count is only returned for multipart objects.
 		return false
 	}
 
@@ -226,44 +231,64 @@ func (h *ObjectHandlers) handlePartNumber(w http.ResponseWriter, r *http.Request
 		return true
 	}
 
+	// For multipart objects, serve the full object with part metadata headers.
+	// Full per-part range serving requires storing per-part sizes in object metadata.
 	w.Header().Set("x-amz-mp-parts-count", strconv.Itoa(obj.PartsCount))
 	return false
 }
-
-// GetObjectAttributes handles GET /{bucket}/{key}?attributes.
 func (h *ObjectHandlers) GetObjectAttributes(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
 	obj, ok := h.loadObjectForRead(w, r, bucketName, key)
 	if !ok {
 		return
 	}
+	// AWS requires this header; default to all if not provided.
+	attrHeader := r.Header.Get("x-amz-object-attributes")
+	requested := make(map[string]bool)
+	if attrHeader != "" {
+		for _, attr := range strings.Split(attrHeader, ",") {
+			requested[strings.TrimSpace(strings.ToLower(attr))] = true
+		}
+	} else {
+		// If no header, return all attributes (broad compatibility).
+		requested["etag"] = true
+		requested["checksum"] = true
+		requested["objectparts"] = true
+		requested["storageclass"] = true
+	}
 
 	var objectParts *ObjectPartsInfo
-	if obj.IsMultipart {
+	if obj.IsMultipart && requested["objectparts"] {
 		objectParts = &ObjectPartsInfo{PartsCount: obj.PartsCount}
 	}
 
 	var checksum *ObjectChecksum
-	if obj.ChecksumCRC32 != "" || obj.ChecksumCRC32C != "" || obj.ChecksumCRC64NVME != "" || obj.ChecksumSHA1 != "" || obj.ChecksumSHA256 != "" {
+	if requested["checksum"] && (obj.ChecksumCRC32 != "" || obj.ChecksumCRC32C != "" || obj.ChecksumCRC64NVME != "" || obj.ChecksumSHA1 != "" || obj.ChecksumSHA256 != "") {
 		checksum = &ObjectChecksum{
-			ChecksumCRC32:    obj.ChecksumCRC32,
-			ChecksumCRC32C:   obj.ChecksumCRC32C,
+			ChecksumCRC32:     obj.ChecksumCRC32,
+			ChecksumCRC32C:    obj.ChecksumCRC32C,
 			ChecksumCRC64NVME: obj.ChecksumCRC64NVME,
-			ChecksumSHA1:     obj.ChecksumSHA1,
-			ChecksumSHA256:   obj.ChecksumSHA256,
+			ChecksumSHA1:      obj.ChecksumSHA1,
+			ChecksumSHA256:    obj.ChecksumSHA256,
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/xml")
-	w.WriteHeader(http.StatusOK)
-	_ = xml.NewEncoder(w).Encode(GetObjectAttributesResult{
-		ETag:         quoteETag(obj.ETag),
+	result := GetObjectAttributesResult{
 		LastModified: obj.UpdatedAt.Format(time.RFC3339),
 		ObjectSize:   obj.Size,
-		StorageClass: "STANDARD",
-		ObjectParts:  objectParts,
-		Checksum:     checksum,
-	})
+	}
+	if requested["etag"] {
+		result.ETag = quoteETag(obj.ETag)
+	}
+	if requested["storageclass"] {
+		result.StorageClass = "STANDARD"
+	}
+	result.ObjectParts = objectParts
+	result.Checksum = checksum
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(result)
 }
 
 func (h *ObjectHandlers) DeleteObject(w http.ResponseWriter, r *http.Request) {

--- a/internal/s3/object_handlers.go
+++ b/internal/s3/object_handlers.go
@@ -1,9 +1,11 @@
 package s3
 
 import (
+	"encoding/xml"
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -34,6 +36,26 @@ type ObjectHandlers struct {
 
 	uploadLocksMu sync.Mutex
 	uploadLocks   map[string]*uploadLock
+}
+
+// parseMetadataHeaders extracts x-amz-meta-* headers from the request.
+// It returns the metadata with lowercased keys, matching AWS S3 conventions.
+func parseMetadataHeaders(r *http.Request) map[string]string {
+	meta := make(map[string]string)
+	const prefix = "x-amz-meta-"
+	for key, vals := range r.Header {
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, prefix) {
+			name := lower[len(prefix):]
+			if len(vals) > 0 {
+				meta[name] = vals[0]
+			}
+		}
+	}
+	if len(meta) == 0 {
+		return nil
+	}
+	return meta
 }
 
 type uploadLock struct {
@@ -116,15 +138,16 @@ func (h *ObjectHandlers) PutObject(w http.ResponseWriter, r *http.Request) {
 	}
 
 	obj := &metadata.Object{
-		ID:          h.newID(),
-		BucketName:  bucketName,
-		Key:         key,
-		Size:        size,
-		ETag:        pipeline.ETag(),
-		ContentType: contentType,
-		StoragePath: storagePath,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:           h.newID(),
+		BucketName:   bucketName,
+		Key:          key,
+		Size:         size,
+		ETag:         pipeline.ETag(),
+		ContentType:  contentType,
+		StoragePath:  storagePath,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		UserMetadata: parseMetadataHeaders(r),
 	}
 
 	if err := h.Objects.Create(r.Context(), obj); err != nil {
@@ -146,11 +169,14 @@ func (h *ObjectHandlers) PutObject(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("ETag", quoteETag(obj.ETag))
 	w.WriteHeader(http.StatusOK)
 }
-
 func (h *ObjectHandlers) GetObject(w http.ResponseWriter, r *http.Request) {
 	bucketName, key := objectRouteParams(r)
 	obj, ok := h.loadObjectForRead(w, r, bucketName, key)
 	if !ok {
+		return
+	}
+
+	if h.handlePartNumber(w, r, obj) {
 		return
 	}
 
@@ -164,7 +190,80 @@ func (h *ObjectHandlers) HeadObject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.handlePartNumber(w, r, obj) {
+		return
+	}
+
 	h.serveObject(w, r, obj, h.S3CacheControl, mapAuthenticatedStorageReadError)
+}
+
+// handlePartNumber handles the partNumber query parameter for GetObject/HeadObject.
+// Returns true if the response was written (error or full part response).
+func (h *ObjectHandlers) handlePartNumber(w http.ResponseWriter, r *http.Request, obj *metadata.Object) bool {
+	partNumStr := r.URL.Query().Get("partNumber")
+	if partNumStr == "" {
+		return false
+	}
+
+	partNumber, err := strconv.Atoi(partNumStr)
+	if err != nil || partNumber < 1 {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidArgument, messageInvalidArgument)
+		return true
+	}
+
+	if !obj.IsMultipart {
+		if partNumber != 1 {
+			WriteS3Error(w, r, http.StatusBadRequest, codeInvalidPart, messageInvalidPart)
+			return true
+		}
+		// PartNumber=1 on a non-multipart object returns the full object.
+		w.Header().Set("x-amz-mp-parts-count", "1")
+		return false
+	}
+
+	if partNumber > obj.PartsCount {
+		WriteS3Error(w, r, http.StatusBadRequest, codeInvalidPart, messageInvalidPart)
+		return true
+	}
+
+	w.Header().Set("x-amz-mp-parts-count", strconv.Itoa(obj.PartsCount))
+	return false
+}
+
+// GetObjectAttributes handles GET /{bucket}/{key}?attributes.
+func (h *ObjectHandlers) GetObjectAttributes(w http.ResponseWriter, r *http.Request) {
+	bucketName, key := objectRouteParams(r)
+	obj, ok := h.loadObjectForRead(w, r, bucketName, key)
+	if !ok {
+		return
+	}
+
+	var objectParts *ObjectPartsInfo
+	if obj.IsMultipart {
+		objectParts = &ObjectPartsInfo{PartsCount: obj.PartsCount}
+	}
+
+	var checksum *ObjectChecksum
+	if obj.ChecksumCRC32 != "" || obj.ChecksumCRC32C != "" || obj.ChecksumCRC64NVME != "" || obj.ChecksumSHA1 != "" || obj.ChecksumSHA256 != "" {
+		checksum = &ObjectChecksum{
+			ChecksumCRC32:    obj.ChecksumCRC32,
+			ChecksumCRC32C:   obj.ChecksumCRC32C,
+			ChecksumCRC64NVME: obj.ChecksumCRC64NVME,
+			ChecksumSHA1:     obj.ChecksumSHA1,
+			ChecksumSHA256:   obj.ChecksumSHA256,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/xml")
+	w.WriteHeader(http.StatusOK)
+	_ = xml.NewEncoder(w).Encode(GetObjectAttributesResult{
+		ETag:         quoteETag(obj.ETag),
+		LastModified: obj.UpdatedAt.Format(time.RFC3339),
+		ObjectSize:   obj.Size,
+		StorageClass: "STANDARD",
+		ObjectParts:  objectParts,
+		Checksum:     checksum,
+	})
 }
 
 func (h *ObjectHandlers) DeleteObject(w http.ResponseWriter, r *http.Request) {
@@ -200,6 +299,39 @@ func (h *ObjectHandlers) writeStorageMutationError(w http.ResponseWriter, r *htt
 
 	h.logError("mutate object backing file", err, bucketName, key, storagePath)
 	WriteS3Error(w, r, http.StatusInternalServerError, codeInternalError, messageInternalError)
+}
+
+// checkPreconditionFailed returns true and writes an S3 error if the
+// conditional headers (If-Match / If-None-Match) reject the request.
+func (h *ObjectHandlers) checkPreconditionFailed(w http.ResponseWriter, r *http.Request, obj *metadata.Object) bool {
+	ifMatch := r.Header.Get("If-Match")
+	ifNoneMatch := r.Header.Get("If-None-Match")
+	if ifMatch == "" && ifNoneMatch == "" {
+		return false
+	}
+
+	if obj == nil && ifMatch != "" {
+		// S3 returns NoSuchKey (not PreconditionFailed) when If-Match is
+		// specified and the object does not exist. Let the caller handle 404.
+		return false
+	}
+
+	if obj != nil {
+		if ifMatch != "" && ifMatch != "*" && !strings.EqualFold(unquoteETag(ifMatch), unquoteETag(obj.ETag)) {
+			WriteS3Error(w, r, http.StatusPreconditionFailed, codePreconditionFailed, messagePreconditionFailed)
+			return true
+		}
+		if ifNoneMatch == "*" {
+			WriteS3Error(w, r, http.StatusPreconditionFailed, codePreconditionFailed, messagePreconditionFailed)
+			return true
+		}
+		if ifNoneMatch != "" && ifNoneMatch != "*" && strings.EqualFold(unquoteETag(ifNoneMatch), unquoteETag(obj.ETag)) {
+			WriteS3Error(w, r, http.StatusPreconditionFailed, codePreconditionFailed, messagePreconditionFailed)
+			return true
+		}
+	}
+
+	return false
 }
 
 func (h *ObjectHandlers) now() time.Time {

--- a/internal/s3/object_read.go
+++ b/internal/s3/object_read.go
@@ -59,6 +59,15 @@ func setObjectHeaders(w http.ResponseWriter, obj *metadata.Object, cacheControl 
 	if cacheControl != "" {
 		w.Header().Set("Cache-Control", cacheControl)
 	}
+	if obj.IsMultipart && obj.PartsCount > 0 {
+		w.Header().Set("x-amz-mp-parts-count", strconv.Itoa(obj.PartsCount))
+	}
+	for key, val := range obj.UserMetadata {
+		// Use direct map write to preserve lowercase x-amz-meta-* header name.
+		// Go's Header.Set() would canonicalize "x-amz-meta-foo" to "X-Amz-Meta-Foo",
+		// which causes botocore to read the metadata key as "Foo" instead of "foo".
+		w.Header()["x-amz-meta-"+key] = []string{val}
+	}
 }
 
 func mapAuthenticatedStorageReadError(w http.ResponseWriter, r *http.Request, h *ObjectHandlers, err error, obj *metadata.Object) {

--- a/internal/s3/routes.go
+++ b/internal/s3/routes.go
@@ -4,6 +4,7 @@ import "github.com/go-chi/chi/v5"
 
 func RegisterBucketRoutes(r chi.Router, h *ObjectHandlers) {
 	r.Get("/", h.ListBuckets)
+	r.Post("/{bucket}", h.DispatchBucketPost)
 	r.Put("/{bucket}", h.DispatchBucketPut)
 	r.Get("/{bucket}", h.DispatchBucketGet)
 	r.Head("/{bucket}", h.HeadBucket)

--- a/internal/s3/routes.go
+++ b/internal/s3/routes.go
@@ -11,6 +11,12 @@ func RegisterBucketRoutes(r chi.Router, h *ObjectHandlers) {
 	// Multi-object delete is POST /{bucket}?delete per the S3 API (boto3/aws-cli).
 	// DELETE /{bucket}?delete is also accepted for older clients and in-repo tests.
 	r.Post("/{bucket}", h.DispatchBucketPost)
+	r.Put("/{bucket}", h.DispatchBucketPut)
+	r.Get("/{bucket}", h.DispatchBucketGet)
+	r.Head("/{bucket}", h.HeadBucket)
+	// Multi-object delete is POST /{bucket}?delete per the S3 API (boto3/aws-cli).
+	// DELETE /{bucket}?delete is also accepted for older clients and in-repo tests.
+	r.Delete("/{bucket}", h.DispatchBucketDelete)
 	r.Delete("/{bucket}", h.DispatchBucketDelete)
 }
 

--- a/internal/s3/routes.go
+++ b/internal/s3/routes.go
@@ -4,10 +4,6 @@ import "github.com/go-chi/chi/v5"
 
 func RegisterBucketRoutes(r chi.Router, h *ObjectHandlers) {
 	r.Get("/", h.ListBuckets)
-	r.Post("/{bucket}", h.DispatchBucketPost)
-	r.Put("/{bucket}", h.DispatchBucketPut)
-	r.Get("/{bucket}", h.DispatchBucketGet)
-	r.Head("/{bucket}", h.HeadBucket)
 	// Multi-object delete is POST /{bucket}?delete per the S3 API (boto3/aws-cli).
 	// DELETE /{bucket}?delete is also accepted for older clients and in-repo tests.
 	r.Post("/{bucket}", h.DispatchBucketPost)
@@ -16,7 +12,6 @@ func RegisterBucketRoutes(r chi.Router, h *ObjectHandlers) {
 	r.Head("/{bucket}", h.HeadBucket)
 	// Multi-object delete is POST /{bucket}?delete per the S3 API (boto3/aws-cli).
 	// DELETE /{bucket}?delete is also accepted for older clients and in-repo tests.
-	r.Delete("/{bucket}", h.DispatchBucketDelete)
 	r.Delete("/{bucket}", h.DispatchBucketDelete)
 }
 

--- a/internal/s3/xml.go
+++ b/internal/s3/xml.go
@@ -160,6 +160,7 @@ type ListPartsPart struct {
 
 type GetObjectAttributesResult struct {
 	XMLName      xml.Name          `xml:"GetObjectAttributesResult"`
+	Xmlns        string            `xml:"xmlns,attr"`
 	ETag         string            `xml:"ETag"`
 	LastModified string            `xml:"LastModified"`
 	ObjectSize   int64             `xml:"ObjectSize"`

--- a/internal/s3/xml.go
+++ b/internal/s3/xml.go
@@ -6,6 +6,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
+
+	appmiddleware "github.com/i-got-this-faa/fbs/internal/http/middleware"
 )
 
 type S3Error struct {
@@ -24,21 +26,27 @@ func WriteS3Error(w http.ResponseWriter, r *http.Request, status int, code, mess
 		return
 	}
 
+	requestID := appmiddleware.GetRequestID(r.Context())
+	if requestID == "" {
+		requestID = "local-0001"
+	}
 	_ = xml.NewEncoder(w).Encode(S3Error{
 		Code:      code,
 		Message:   message,
 		Resource:  r.URL.Path,
-		RequestID: "local-0001",
+		RequestID: requestID,
 	})
 }
 
 // Multipart XML types.
 
 type InitiateMultipartUploadResult struct {
-	XMLName  xml.Name `xml:"InitiateMultipartUploadResult"`
-	Bucket   string   `xml:"Bucket"`
-	Key      string   `xml:"Key"`
-	UploadID string   `xml:"UploadId"`
+	XMLName           xml.Name `xml:"InitiateMultipartUploadResult"`
+	Xmlns             string   `xml:"xmlns,attr"`
+	Bucket            string   `xml:"Bucket"`
+	Key               string   `xml:"Key"`
+	UploadID          string   `xml:"UploadId"`
+	ChecksumAlgorithm string   `xml:"ChecksumAlgorithm,omitempty"`
 }
 
 type CompleteMultipartUpload struct {
@@ -53,6 +61,7 @@ type CompletePart struct {
 
 type CompleteMultipartUploadResult struct {
 	XMLName  xml.Name `xml:"CompleteMultipartUploadResult"`
+	Xmlns    string   `xml:"xmlns,attr"`
 	Location string   `xml:"Location"`
 	Bucket   string   `xml:"Bucket"`
 	Key      string   `xml:"Key"`
@@ -87,4 +96,108 @@ func unquoteETag(etag string) string {
 		return etag[1 : len(etag)-1]
 	}
 	return etag
+}
+
+type CopyPartResult struct {
+	XMLName      xml.Name `xml:"CopyPartResult"`
+	LastModified string   `xml:"LastModified"`
+	ETag         string   `xml:"ETag"`
+}
+
+type ListMultipartUploadsResult struct {
+	XMLName            xml.Name             `xml:"ListMultipartUploadsResult"`
+	Xmlns              string               `xml:"xmlns,attr"`
+	Bucket             string               `xml:"Bucket"`
+	KeyMarker          string               `xml:"KeyMarker,omitempty"`
+	UploadIDMarker     string               `xml:"UploadIdMarker,omitempty"`
+	NextKeyMarker      string               `xml:"NextKeyMarker,omitempty"`
+	NextUploadIDMarker string               `xml:"NextUploadIdMarker,omitempty"`
+	MaxUploads         int                  `xml:"MaxUploads"`
+	IsTruncated        bool                 `xml:"IsTruncated"`
+	Upload             []MultipartUploadEntry `xml:"Upload,omitempty"`
+	Delimiter          string               `xml:"Delimiter,omitempty"`
+	Prefix             string               `xml:"Prefix,omitempty"`
+	CommonPrefixes     []listCommonPrefix   `xml:"CommonPrefixes,omitempty"`
+}
+
+type MultipartUploadEntry struct {
+	Key          string `xml:"Key"`
+	UploadID     string `xml:"UploadId"`
+	Initiator    Owner  `xml:"Initiator"`
+	Owner        Owner  `xml:"Owner"`
+	StorageClass string `xml:"StorageClass"`
+	Initiated    string `xml:"Initiated"`
+}
+
+type Owner struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName"`
+}
+
+type ListPartsResult struct {
+	XMLName              xml.Name        `xml:"ListPartsResult"`
+	Xmlns                string          `xml:"xmlns,attr"`
+	Bucket               string          `xml:"Bucket"`
+	Key                  string          `xml:"Key"`
+	UploadID             string          `xml:"UploadId"`
+	Initiator            Owner           `xml:"Initiator"`
+	Owner                Owner           `xml:"Owner"`
+	StorageClass         string          `xml:"StorageClass"`
+	PartNumberMarker     int             `xml:"PartNumberMarker,omitempty"`
+	NextPartNumberMarker int             `xml:"NextPartNumberMarker,omitempty"`
+	MaxParts             int             `xml:"MaxParts"`
+	IsTruncated          bool            `xml:"IsTruncated"`
+	Part                 []ListPartsPart `xml:"Part,omitempty"`
+}
+
+type ListPartsPart struct {
+	PartNumber        int    `xml:"PartNumber"`
+	LastModified      string `xml:"LastModified"`
+	ETag              string `xml:"ETag"`
+	Size              int64  `xml:"Size"`
+	ChecksumAlgorithm string `xml:"ChecksumAlgorithm,omitempty"`
+}
+
+type GetObjectAttributesResult struct {
+	XMLName      xml.Name          `xml:"GetObjectAttributesResult"`
+	ETag         string            `xml:"ETag"`
+	LastModified string            `xml:"LastModified"`
+	ObjectSize   int64             `xml:"ObjectSize"`
+	StorageClass string            `xml:"StorageClass"`
+	ObjectParts  *ObjectPartsInfo  `xml:"ObjectParts,omitempty"`
+	Checksum     *ObjectChecksum   `xml:"Checksum,omitempty"`
+}
+
+type ObjectPartsInfo struct {
+	PartsCount int `xml:"PartsCount"`
+}
+
+type ObjectChecksum struct {
+	ChecksumCRC32    string `xml:"ChecksumCRC32,omitempty"`
+	ChecksumCRC32C   string `xml:"ChecksumCRC32C,omitempty"`
+	ChecksumCRC64NVME string `xml:"ChecksumCRC64NVME,omitempty"`
+	ChecksumSHA1     string `xml:"ChecksumSHA1,omitempty"`
+	ChecksumSHA256   string `xml:"ChecksumSHA256,omitempty"`
+}
+
+type ListVersionsResult struct {
+	XMLName       xml.Name           `xml:"ListVersionsResult"`
+	Xmlns         string             `xml:"xmlns,attr"`
+	Name          string             `xml:"Name"`
+	Prefix        string             `xml:"Prefix"`
+	KeyMarker     string             `xml:"KeyMarker"`
+	NextKeyMarker string             `xml:"NextKeyMarker,omitempty"`
+	MaxKeys       int                `xml:"MaxKeys"`
+	IsTruncated   bool               `xml:"IsTruncated"`
+	Version       []ListVersionsEntry `xml:"Version,omitempty"`
+}
+
+type ListVersionsEntry struct {
+	Key          string `xml:"Key"`
+	VersionID    string `xml:"VersionId"`
+	IsLatest     bool   `xml:"IsLatest"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
 }

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -1,4 +1,4 @@
--- Initialize the database schema (v1 — matches runtime migration version 1).
+-- Initialize the database schema (v1 -- matches runtime migration version 1).
 -- SigV4 columns are added by migration 2 at application startup.
 
 CREATE TABLE IF NOT EXISTS users (
@@ -28,6 +28,12 @@ CREATE TABLE IF NOT EXISTS objects (
     storage_path   TEXT NOT NULL,
     created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_multipart   INTEGER NOT NULL DEFAULT 0,
+    checksum_crc32    TEXT,
+    checksum_crc32c   TEXT,
+    checksum_crc64nvme TEXT,
+    checksum_sha1     TEXT,
+    checksum_sha256   TEXT,
     UNIQUE(bucket_name, key)
 );
 
@@ -50,6 +56,11 @@ CREATE TABLE IF NOT EXISTS multipart_parts (
     etag         TEXT NOT NULL,
     storage_path TEXT NOT NULL,
     created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    checksum_crc32    TEXT,
+    checksum_crc32c   TEXT,
+    checksum_crc64nvme TEXT,
+    checksum_sha1     TEXT,
+    checksum_sha256   TEXT,
     PRIMARY KEY (upload_id, part_number)
 );
 

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -275,6 +275,8 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
 }
 
 // addColumnIfMissing adds a column to a table if it doesn't already exist.
+// Only trusted literal strings may be passed — all arguments are interpolated
+// directly into SQL with no parameterization.
 func addColumnIfMissing(tx *sql.Tx, table, name, typ, def string) error {
 	var count int
 	err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('`+table+`') WHERE name = ?`, name).Scan(&count)

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -223,15 +223,7 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
 		name:    "add multipart part checksums",
 		run: func(tx *sql.Tx) error {
 			for _, col := range []string{"checksum_crc32", "checksum_crc32c", "checksum_crc64nvme", "checksum_sha1", "checksum_sha256"} {
-				var count int
-				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('multipart_parts') WHERE name = ?`, col).Scan(&count)
-				if err != nil {
-					return err
-				}
-				if count > 0 {
-					continue
-				}
-				if _, err := tx.Exec(`ALTER TABLE multipart_parts ADD COLUMN ` + col + ` TEXT`); err != nil {
+				if err := addColumnIfMissing(tx, "multipart_parts", col, "TEXT", ""); err != nil {
 					return err
 				}
 			}
@@ -242,28 +234,15 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
 		version: 10,
 		name:    "add object is_multipart and checksums",
 		run: func(tx *sql.Tx) error {
-			columns := []struct{ name, typ, def string }{
+			for _, col := range []struct{ name, typ, def string }{
 				{"is_multipart", "INTEGER", "0"},
 				{"checksum_crc32", "TEXT", ""},
 				{"checksum_crc32c", "TEXT", ""},
 				{"checksum_crc64nvme", "TEXT", ""},
 				{"checksum_sha1", "TEXT", ""},
 				{"checksum_sha256", "TEXT", ""},
-			}
-			for _, col := range columns {
-				var count int
-				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('objects') WHERE name = ?`, col.name).Scan(&count)
-				if err != nil {
-					return err
-				}
-				if count > 0 {
-					continue
-				}
-				sql := `ALTER TABLE objects ADD COLUMN ` + col.name + ` ` + col.typ
-				if col.def != "" {
-					sql += ` NOT NULL DEFAULT ` + col.def
-				}
-				if _, err := tx.Exec(sql); err != nil {
+			} {
+				if err := addColumnIfMissing(tx, "objects", col.name, col.typ, col.def); err != nil {
 					return err
 				}
 			}
@@ -278,19 +257,7 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
 				{"checksum_algorithm", "TEXT", ""},
 				{"user_metadata", "TEXT", ""},
 			} {
-				var count int
-				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('multipart_uploads') WHERE name = ?`, col.name).Scan(&count)
-				if err != nil {
-					return err
-				}
-				if count > 0 {
-					continue
-				}
-				sql := `ALTER TABLE multipart_uploads ADD COLUMN ` + col.name + ` ` + col.typ
-				if col.def != "" {
-					sql += ` NOT NULL DEFAULT ` + col.def
-				}
-				if _, err := tx.Exec(sql); err != nil {
+				if err := addColumnIfMissing(tx, "multipart_uploads", col.name, col.typ, col.def); err != nil {
 					return err
 				}
 			}
@@ -298,25 +265,33 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
 				{"parts_count", "INTEGER", "0"},
 				{"user_metadata", "TEXT", ""},
 			} {
-				var count int
-				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('objects') WHERE name = ?`, col.name).Scan(&count)
-				if err != nil {
-					return err
-				}
-				if count > 0 {
-					continue
-				}
-				sql := `ALTER TABLE objects ADD COLUMN ` + col.name + ` ` + col.typ
-				if col.def != "" {
-					sql += ` NOT NULL DEFAULT ` + col.def
-				}
-				if _, err := tx.Exec(sql); err != nil {
+				if err := addColumnIfMissing(tx, "objects", col.name, col.typ, col.def); err != nil {
 					return err
 				}
 			}
 			return nil
 		},
 	},
+}
+
+// addColumnIfMissing adds a column to a table if it doesn't already exist.
+func addColumnIfMissing(tx *sql.Tx, table, name, typ, def string) error {
+	var count int
+	err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('`+table+`') WHERE name = ?`, name).Scan(&count)
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	sql := `ALTER TABLE ` + table + ` ADD COLUMN ` + name + ` ` + typ
+	if def != "" {
+		sql += ` NOT NULL DEFAULT ` + def
+	}
+	if _, err := tx.Exec(sql); err != nil {
+		return err
+	}
+	return nil
 }
 
 func ensureMigrationsTable(db *sql.DB) error {

--- a/migrations/migration.go
+++ b/migrations/migration.go
@@ -218,6 +218,105 @@ CREATE INDEX IF NOT EXISTS idx_grants_bucket
     ON grants(bucket_name);
 `,
 	},
+	{
+		version: 9,
+		name:    "add multipart part checksums",
+		run: func(tx *sql.Tx) error {
+			for _, col := range []string{"checksum_crc32", "checksum_crc32c", "checksum_crc64nvme", "checksum_sha1", "checksum_sha256"} {
+				var count int
+				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('multipart_parts') WHERE name = ?`, col).Scan(&count)
+				if err != nil {
+					return err
+				}
+				if count > 0 {
+					continue
+				}
+				if _, err := tx.Exec(`ALTER TABLE multipart_parts ADD COLUMN ` + col + ` TEXT`); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
+	{
+		version: 10,
+		name:    "add object is_multipart and checksums",
+		run: func(tx *sql.Tx) error {
+			columns := []struct{ name, typ, def string }{
+				{"is_multipart", "INTEGER", "0"},
+				{"checksum_crc32", "TEXT", ""},
+				{"checksum_crc32c", "TEXT", ""},
+				{"checksum_crc64nvme", "TEXT", ""},
+				{"checksum_sha1", "TEXT", ""},
+				{"checksum_sha256", "TEXT", ""},
+			}
+			for _, col := range columns {
+				var count int
+				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('objects') WHERE name = ?`, col.name).Scan(&count)
+				if err != nil {
+					return err
+				}
+				if count > 0 {
+					continue
+				}
+				sql := `ALTER TABLE objects ADD COLUMN ` + col.name + ` ` + col.typ
+				if col.def != "" {
+					sql += ` NOT NULL DEFAULT ` + col.def
+				}
+				if _, err := tx.Exec(sql); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
+	{
+		version: 11,
+		name:    "add checksum_algorithm, parts_count, user_metadata",
+		run: func(tx *sql.Tx) error {
+			for _, col := range []struct{ name, typ, def string }{
+				{"checksum_algorithm", "TEXT", ""},
+				{"user_metadata", "TEXT", ""},
+			} {
+				var count int
+				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('multipart_uploads') WHERE name = ?`, col.name).Scan(&count)
+				if err != nil {
+					return err
+				}
+				if count > 0 {
+					continue
+				}
+				sql := `ALTER TABLE multipart_uploads ADD COLUMN ` + col.name + ` ` + col.typ
+				if col.def != "" {
+					sql += ` NOT NULL DEFAULT ` + col.def
+				}
+				if _, err := tx.Exec(sql); err != nil {
+					return err
+				}
+			}
+			for _, col := range []struct{ name, typ, def string }{
+				{"parts_count", "INTEGER", "0"},
+				{"user_metadata", "TEXT", ""},
+			} {
+				var count int
+				err := tx.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('objects') WHERE name = ?`, col.name).Scan(&count)
+				if err != nil {
+					return err
+				}
+				if count > 0 {
+					continue
+				}
+				sql := `ALTER TABLE objects ADD COLUMN ` + col.name + ` ` + col.typ
+				if col.def != "" {
+					sql += ` NOT NULL DEFAULT ` + col.def
+				}
+				if _, err := tx.Exec(sql); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	},
 }
 
 func ensureMigrationsTable(db *sql.DB) error {

--- a/migrations/migration_test.go
+++ b/migrations/migration_test.go
@@ -64,8 +64,8 @@ func TestRun_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Errorf("migration count = %d, want 8", count)
+	if count != 11 {
+		t.Errorf("migration count = %d, want 11", count)
 	}
 }
 
@@ -157,8 +157,8 @@ func TestRun_BootstrapFromInitSQL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Errorf("migration count = %d, want 8", count)
+	if count != 11 {
+		t.Errorf("migration count = %d, want 11", count)
 	}
 
 	// Verify sigv4 columns were added by v2

--- a/plan/access-control/access-control.md
+++ b/plan/access-control/access-control.md
@@ -715,7 +715,8 @@ changes):
 The system is correct with respect to this architecture when all of the
 following hold:
 
-1. A member can receive read-only access to another user’s bucket and
+1. A member can receive read-only object GET access (mapped to `s3:GetObject`) or
+   bucket-list access (mapped to `s3:ListBucket`) via separate grants, and
    successfully get/list within grant scope without Management admin.
 2. A member can receive write access limited to a key prefix and cannot
    read or write outside that prefix.

--- a/plan/s3-compatibility.md
+++ b/plan/s3-compatibility.md
@@ -108,9 +108,11 @@ replication — everything lives on one disk.
 
 ### Consistency
 
-**AWS S3** provides read-after-write strong consistency for PUTs of new
-objects (most regions as of late 2020), with eventual consistency for some
-overwrite and delete operations in legacy scenarios.
+**AWS S3** has provided strong read-after-write consistency for all object
+operations (PUT, POST, DELETE, overwrite, GET, HEAD, LIST, multipart)
+since December 2020 in all commercial regions. Bucket-configuration
+changes (e.g., enabling versioning, modifying bucket policies) remain
+eventually consistent.
 
 **fbs-core** is **strongly consistent** for all operations — SQLite is the
 source of truth, and the write path uses an atomic rename + metadata upsert
@@ -170,8 +172,11 @@ later; until then they remain compatibility gaps, not promises.
 
 ## Compatibility testing
 
-Use `compat/s3-tests/` for AWS-like gap discovery. The default core filter
-drops permanent non-goals and large deferred clusters; see
+Use `compat/s3-tests/` for AWS-like gap discovery. The default `--core`
+filter drops only tests explicitly marked as permanent non-goals or large
+deferred clusters in the markers file; unmarked upstream tests still run
+and may produce failures. `--core` is not a complete exclusion or a
+guaranteed-green compatibility gate — see
 [`compat/s3-tests/markers.md`](../compat/s3-tests/markers.md).
 
 Claimed behavior is enforced by `go test ./...`, not by s3-tests CI gates.


### PR DESCRIPTION
This pull request introduces an S3 compatibility testing suite using the upstream `ceph/s3-tests` framework, along with supporting documentation, configuration, and a patch to enable compatibility with fbs-core. It also updates the server to apply S3-specific headers middleware to S3 API routes. The most important changes are summarized below.

---

**S3 Compatibility Testing Suite:**

* Added the `compat/s3-tests` directory, including a detailed `README.md` that explains how to run, interpret, and maintain the S3 compatibility test suite, which is based on `ceph/s3-tests` and includes scripts for running tests, generating reports, and maintaining a shared feature checklist.
* Introduced a patch script (`patches/apply-nuke-fallback.py`) that rewrites upstream s3-tests cleanup logic to support servers without versioning or object lock, ensuring tests can run and clean up properly on fbs-core.
* Added a marker filter (`markers.core`) and rationale documentation (`markers.md`) to select the relevant subset of S3 tests that match fbs-core’s implemented and planned feature set, and to document why certain tests are excluded. [[1]](diffhunk://#diff-dc45cf4467dce470f9eaff7d517337d790421289a58f04c71e814cb346ca5028R1-R69) [[2]](diffhunk://#diff-b3c97bfa5690020b0f0f99033a6131f7839ff15c7957964adae6d5d4ae981c1dR1-R189)

**Server Middleware Updates:**

* Updated `cmd/server/main.go` to apply the S3-specific headers middleware (`S3Headers`) to all S3 API routes, ensuring correct protocol behavior for S3 clients. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR26) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eR164-R170)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added object-level user metadata, multipart per-part checksums/metadata (including CRC64-NVME), checksum algorithms, and GetObjectAttributes responses.
  - Expanded multipart support with copy-part, multipart listing/part listing, and improved multipart completion behavior.
  - Added S3 object versions listing and improved S3 route request-ID headers.

- **Bug Fixes**
  - Improved S3 error mapping for invalid pagination/max-keys.
  - Public URL TTL requests now reject values beyond the configured maximum.
  - Bucket deletion now cleans up pending multipart uploads and better reports non-empty bucket cases.

- **Documentation & Tests**
  - Enhanced the s3-tests compatibility runner documentation, markers, and generated checklist reports; updated related tests and S3 semantics docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->